### PR TITLE
Fix setup_logging missing dependency in how_to_use_ast2vec.ipynb

### DIFF
--- a/doc/how_to_use_ast2vec.ipynb
+++ b/doc/how_to_use_ast2vec.ipynb
@@ -9,7 +9,7 @@
    "outputs": [],
    "source": [
     "# setup logging\n",
-    "from ast2vec import setup_logging\n",
+    "from modelforge.logs import setup_logging\n",
     "setup_logging(level=\"DEBUG\")\n",
     "\n",
     "# setup linguist - mandatory to launch first time to build enry.\n",


### PR DESCRIPTION
Related to https://github.com/src-d/ml/issues/120