### PR TITLE
[MLIP-000] Merge NoopTokenParser and NoTokenParser

### DIFF
--- a/sourced/ml/algorithms/__init__.py
+++ b/sourced/ml/algorithms/__init__.py
@@ -1,2 +1,2 @@
-from sourced.ml.algorithms.token_parser import TokenParser, NoTokenParser
+from sourced.ml.algorithms.token_parser import TokenParser, NoopTokenParser
 from sourced.ml.algorithms.uast_struct_to_bag import UastRandomWalk2Bag, UastSeq2Bag

--- a/sourced/ml/algorithms/token_parser.py
+++ b/sourced/ml/algorithms/token_parser.py
@@ -72,10 +72,10 @@ class TokenParser:
         self._stemmer = Stemmer.Stemmer("english")
 
 
-class NoTokenParser:
+class NoopTokenParser:
     """
     One can use this class if he or she does not want to do any parsing.
     """
 
     def process_token(self, token):
-        return [token]
+        yield token

--- a/sourced/ml/extractors/identifiers.py
+++ b/sourced/ml/extractors/identifiers.py
@@ -1,5 +1,6 @@
 from sourced.ml.algorithms.uast_ids_to_bag import UastIds2Bag
 from sourced.ml.extractors import BagsExtractor, register_extractor
+from sourced.ml.algorithms import NoopTokenParser
 
 
 @register_extractor
@@ -8,14 +9,10 @@ class IdentifiersBagExtractor(BagsExtractor):
     NAMESPACE = "i."
     OPTS = {"split-stem": False}
 
-    class NoopTokenParser:
-        def process_token(self, token):
-            yield token
-
     def __init__(self, docfreq_threshold=None, split_stem=False):
         super().__init__(docfreq_threshold)
         self.id2bag = UastIds2Bag(
-            None, self.NoopTokenParser() if not split_stem else None)
+            None, NoopTokenParser() if not split_stem else None)
 
     def uast_to_bag(self, uast):
         return self.id2bag.uast_to_bag(uast)

--- a/sourced/ml/tests/test_token_parser.py
+++ b/sourced/ml/tests/test_token_parser.py
@@ -1,7 +1,7 @@
 import pickle
 import unittest
 
-from sourced.ml.algorithms import TokenParser, NoTokenParser
+from sourced.ml.algorithms import TokenParser, NoopTokenParser
 
 
 class TokenParserTests(unittest.TestCase):
@@ -39,9 +39,9 @@ class TokenParserTests(unittest.TestCase):
         self.assertEqual(tp.stem("embedding"), "embed")
 
 
-class NoTokenParserTests(unittest.TestCase):
+class NoopTokenParserTests(unittest.TestCase):
     def setUp(self):
-        self.tp = NoTokenParser()
+        self.tp = NoopTokenParser()
 
     def test_process_token(self):
         self.assertEqual(self.tp.process_token("abcdef"), ["abcdef"])


### PR DESCRIPTION
Correspond to https://github.com/src-d/ml/blob/refactor/documentation/proposals/MLIP-000.md#7-move-nooptokenparser-and-hashedtokenparser-to-parcers-and-join-with-notokenparser