### PR TITLE
Add package namespace

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ else:
     typing = []
 
 setup(
-    name="sourcedml",
+    name="sourced-ml",
     description="Part of source{d}'s stack for machine learning on source "
                 "code. Provides API and tools to train and use models based "
                 "on source code identifiers extracted from Babelfish's UASTs.",
@@ -20,6 +20,7 @@ setup(
     url="https://github.com/src-d/ml",
     download_url="https://github.com/src-d/ml",
     packages=find_packages(exclude=("sourced.ml.tests",)),
+    namespace_packages=["sourced"],
     entry_points={
         "console_scripts": ["sourcedml=sourced.ml.__main__:main"],
     },

--- a/sourced/__init__.py
+++ b/sourced/__init__.py
@@ -1,0 +1,3 @@
+# You must not include any other code and data in a namespace package's __init__.py
+import pkg_resources
+pkg_resources.declare_namespace(__name__)


### PR DESCRIPTION
Since we have two python packages in one namespace (`ml` and `engine` in `sourced`) it is good to use package namespace to make them work together.

You can find more info about package namespaces [here](http://setuptools.readthedocs.io/en/latest/setuptools.html#namespace-packages).
One can check that everything works using pure ubuntu (for example using docker `docker run -it ubuntu bash`) and run:

``` bash
apt-get update
apt-get install -y --no-install-suggests --no-install-recommends ca-certificates locales git python3 python3-dev libxml2 libxml2-dev libonig2 make gcc curl
curl https://bootstrap.pypa.io/get-pip.py | python3
mkdir workdir
cd workdir/
git clone https://github.com/zurk/ast2vec.git -b pack_namespace
git clone https://github.com/zurk/engine.git -b feature/pack_namespace
cd engine/python/
pip install -e .
cd ../../ast2vec/
pip install -r requirements.txt
pip install -e .
python3 -c "import sourced.ml; import sourced.engine"

```

If there is no error, then everything is fine: you can import both submodules.

Also I edit name to be consistent with sourced-engine package (https://github.com/src-d/engine/blob/master/python/setup.py#L19)