### PR TITLE
Add extractors with feature engineering

### DIFF
--- a/sourced/ml/algorithms/__init__.py
+++ b/sourced/ml/algorithms/__init__.py
@@ -1,2 +1,3 @@
 from sourced.ml.algorithms.token_parser import TokenParser, NoopTokenParser
 from sourced.ml.algorithms.uast_struct_to_bag import UastRandomWalk2Bag, UastSeq2Bag
+from sourced.ml.algorithms.uast2nodes import UastNode2Bag, Quantization

--- a/sourced/ml/algorithms/uast2nodes.py
+++ b/sourced/ml/algorithms/uast2nodes.py
@@ -1,0 +1,131 @@
+from collections import defaultdict
+import numpy
+
+from sourced.ml.algorithms.uast_ids_to_bag import FakeVocabulary
+
+
+class UastNode2Bag():
+    """
+    Converts a UAST to a bag of features that are node specific.
+    The features can be either (internal types, number of children)
+    or (roles, number of children)
+    """
+    def __init__(self, type2ind=None, roles2ind=None, children2ind=None):
+        """
+        :param type2ind: The mapping from internal types to bag of keys. \
+            If None, no mapping is performed.
+        :param roles2ind: The mapping from roles to bag of keys.
+        :param children2ind: The mapping from the number of children to bag of keys. \
+            :class:'Quantization' is used if it is not specified.
+        """
+        self.type2ind = FakeVocabulary() if type2ind is None else type2ind
+        self.roles2ind = FakeVocabulary() if roles2ind is None else roles2ind
+        self.children2ind = Quantization() if children2ind is None else children2ind
+
+    def _uast2nodes(self, root):
+        """
+        :param uast: The UAST root node.
+        :return: The list of the nodes composing the UAST.
+        """
+        nodes = []
+        queue = [root]
+        while queue:
+            child = queue.pop(0)
+            queue.extend(child.children)
+            nodes.append(child)
+        return nodes
+
+    def _nodes2children(self, nodes):
+        """
+        :param nodes: List of all nodes from a UAST.
+        :return: The list of the number of children of all these nodes.
+        """
+        nb_children = []
+        for n in nodes:
+            nb_children.append(len(n.children))
+        return nb_children
+
+    def uast_to_bag(self, uast, feature):
+        """
+        Converts a UAST to a bag-of-features. The weights are feature frequencies.
+        The number of children are preprocessed by :class:`Quantization`
+
+        :param uast: The UAST root node.
+        :param feature: The first feature we want to extract from the nodes of the UAST.
+        :return:
+        """
+        bag = defaultdict(int)
+        nodes = self._uast2nodes(uast)
+        nb_children = self._nodes2children(nodes)
+        self.children2ind.build_partition(nb_children)
+        for n in nodes:
+            bag[self.node2ind(n, feature)] += 1
+        return bag
+
+    def node2ind(self, node, feature):
+        """
+        str format is required for wmhash.Bags.Extractor
+        :param node: a node of UAST
+        :param feature: The first feature we want to extract from the nodes of the UAST. \
+        This first feature should be either "internal_type" or "roles", \
+        the second being the number of children anyway.
+        :return:
+        """
+        if feature is "internal_type":
+            return " ".join([self.type2ind[node.internal_type],
+                             str(self.children2ind.process_value(len(node.children)))])
+        elif feature is "roles":
+            return " ".join([str(self.roles2ind[node.roles]),
+                             str(self.children2ind.process_value(len(node.children)))])
+        else:
+            raise NotImplementedError
+
+
+class Quantization():
+    """
+    Algorithm that performs the quantization of a list of values.
+    """
+    def __init__(self, fineness=0.005):
+        """
+        :param fineness: The number of partitions grows with the fineness of the quantization. \
+        The fineness parameter must be included between 0 excluded and 1.
+        """
+        self.fineness = fineness
+        self.partition = []
+
+    def build_partition(self, values):
+        """
+        Builds the partition of the quantization.
+        It is a list of increasing integers equally partitioning the distribution of values.
+        The length of the partition list increase with the fineness.
+
+        :param values: List of values we want to quantize
+        :return:
+        """
+        values.sort()
+        max_nodes_per_bin = self.fineness * len(values)
+        unique_values = list(set(values))
+        max_values = max(values)
+        ind = 0
+        while True:
+            nb_nodes_in_bin = 0
+            while (nb_nodes_in_bin < max_nodes_per_bin) and (unique_values[ind] < max_values):
+                nb_nodes_in_bin += len([x for x in values if x == unique_values[ind]])
+                ind += 1
+            if unique_values[ind] != max_values:
+                self.partition.append(unique_values[ind - 1])
+            else:
+                self.partition.append(unique_values[ind] + 1)
+                break
+
+    def process_value(self, value):
+        """
+        Processes value according to the quantization algorithm. \
+        Behaves like a stair function whose set of permissible outputs are the values in partition.
+
+        :param value: value we want to quantize.
+        :return:
+        """
+        linear_values = numpy.arange(len(self.partition))
+        idx = numpy.searchsorted(self.partition, value, side="right")
+        return linear_values[idx-1]

--- a/sourced/ml/extractors/__init__.py
+++ b/sourced/ml/extractors/__init__.py
@@ -5,3 +5,5 @@ from sourced.ml.extractors.identifiers import IdentifiersBagExtractor
 from sourced.ml.extractors.literals import LiteralsBagExtractor
 from sourced.ml.extractors.uast_random_walk import UastRandomWalkBagExtractor
 from sourced.ml.extractors.uast_seq import UastSeqBagExtractor
+from sourced.ml.extractors.internal_type_children import InternalTypeChildrenBagExtractor
+from sourced.ml.extractors.roles_children import RoleTypeChildrenBagExtractor

--- a/sourced/ml/extractors/internal_type_children.py
+++ b/sourced/ml/extractors/internal_type_children.py
@@ -1,0 +1,16 @@
+from sourced.ml.algorithms import UastNode2Bag, Quantization
+from sourced.ml.extractors import BagsExtractor, register_extractor
+
+
+@register_extractor
+class InternalTypeChildrenBagExtractor(BagsExtractor):
+    NAME = "typechildren"
+    NAMESPACE = "tc."
+    OPTS = BagsExtractor.OPTS.copy()
+
+    def __init__(self, docfreq_threshold=None):
+        super().__init__(docfreq_threshold)
+        self.type_children2bag = UastNode2Bag(children2ind=Quantization())
+
+    def uast_to_bag(self, uast):
+        return self.type_children2bag.uast_to_bag(uast, feature="internal_type")

--- a/sourced/ml/extractors/roles_children.py
+++ b/sourced/ml/extractors/roles_children.py
@@ -1,0 +1,16 @@
+from sourced.ml.algorithms import UastNode2Bag, Quantization
+from sourced.ml.extractors import BagsExtractor, register_extractor
+
+
+@register_extractor
+class RoleTypeChildrenBagExtractor(BagsExtractor):
+    NAME = "rolechildren"
+    NAMESPACE = "rc."
+    OPTS = BagsExtractor.OPTS.copy()
+
+    def __init__(self, docfreq_threshold=None):
+        super().__init__(docfreq_threshold)
+        self.role_children2bag = UastNode2Bag(children2ind=Quantization())
+
+    def uast_to_bag(self, uast):
+        return self.role_children2bag.uast_to_bag(uast, feature="roles")

--- a/sourced/ml/tests/test_uast2nodes.py
+++ b/sourced/ml/tests/test_uast2nodes.py
@@ -1,0 +1,22 @@
+import unittest
+
+from bblfsh import BblfshClient
+
+from sourced.ml.algorithms import UastNode2Bag, Quantization
+from sourced.ml.tests.models import SOURCE_PY
+
+
+class UastNode2BagTest(unittest.TestCase):
+    def setUp(self):
+        self.bag_extractor = UastNode2Bag(children2ind=Quantization())
+        self.uast = BblfshClient("0.0.0.0:9432").parse(SOURCE_PY).uast
+
+    def test_uast_to_bag(self):
+        bag_ic = self.bag_extractor.uast_to_bag(self.uast, feature="internal_type")
+        bag_rc = self.bag_extractor.uast_to_bag(self.uast, feature="roles")
+        self.assertTrue(len(bag_ic) > 0, "Expected size of bag should be > 0")
+        self.assertTrue(len(bag_rc) > 0, "Expected size of bag should be > 0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Corresponding issue : 
* https://github.com/src-d/backlog/issues/1100
* https://github.com/src-d/backlog/issues/1142

The first commit includes 2 different new extractors where the features are : 
* (interanl_type, number of children)
* (roles, number of children)
Both with quantization of the number of children
