### PR TITLE
Fix random walk algorithm.

### DIFF
--- a/sourced/ml/algorithms/uast_struct_to_bag.py
+++ b/sourced/ml/algorithms/uast_struct_to_bag.py
@@ -148,10 +148,13 @@ class Uast2RandomWalks:
         """
         last_node = walk[-1]  # correspond to node v in article
 
-        if len(walk) == 1 and len(last_node.children) > 0:
+        if len(walk) == 1:
+            choice_list = last_node.children
+            if last_node.parent is not None:
+                choice_list.append(last_node.parent)
+            if len(choice_list) == 0:
+                return last_node
             return random.choice(last_node.children)
-        elif len(last_node.children) == 0:
-            return last_node
 
         threshold = (1 / self.p_explore_neighborhood)
         threshold /= (threshold + len(last_node.children) / self.q_leave_neighborhood)

--- a/sourced/ml/tests/test_random_walk.py
+++ b/sourced/ml/tests/test_random_walk.py
@@ -1,0 +1,29 @@
+import unittest
+
+import bblfsh
+
+from sourced.ml.tests import models
+from sourced.ml.algorithms.uast_struct_to_bag import Uast2RandomWalks
+from sourced.ml.algorithms.uast_ids_to_bag import FakeVocabulary
+
+
+class RandomWalkTests(unittest.TestCase):
+    def setUp(self):
+        self.bblfsh = bblfsh.BblfshClient("localhost:9432")
+        self.uast = self.bblfsh.parse(models.SOURCE_PY).uast
+        self.uast2walk = Uast2RandomWalks(p_explore_neighborhood=0.5,
+                                          q_leave_neighborhood=0.5,
+                                          n_walks=5,
+                                          n_steps=19,
+                                          node2index=FakeVocabulary(),
+                                          seed=42)
+
+    def test_rw(self):
+        for walk in self.uast2walk(self.uast):
+            for i in range(len(walk)-1):
+                self.assertNotEqual(walk[i], walk[i+1],
+                                    "Two neighbours nodes should not be the same")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Random walk stucks in case there are two same nodes in walk one after another. It should not happen at all.
Also, test added.
Signed-off-by: Konstantin Slavnov konstantin@sourced.tech