### PR TITLE
Wrap import of tensorflow to avoid import error

### DIFF
--- a/sourced/ml/cmd_entries/preprocess_id2vec.py
+++ b/sourced/ml/cmd_entries/preprocess_id2vec.py
@@ -3,7 +3,10 @@ import os
 import shutil
 
 import numpy
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError as e:
+    logging.warn("Tensorflow is not installed, dependent functionality is unavailable.")
 
 from modelforge.progress_bar import progress_bar
 from sourced.ml.algorithms.id_embedding import _extract_coocc_matrix

--- a/sourced/ml/cmd_entries/run_swivel.py
+++ b/sourced/ml/cmd_entries/run_swivel.py
@@ -1,19 +1,27 @@
 import argparse
 import logging
 
-from sourced.ml.algorithms import swivel as swivel
+try:
+    from sourced.ml.algorithms import swivel as swivel
 
+    def mirror_tf_args(parser: argparse.ArgumentParser):
+        """
+        Copies the command line flags registered in swivel.py to an :class:
+        `argparse.ArgumentParser`.
+        :param parser: object to copy flags to.
+        :return: None
+        """
+        types = {"string": str, "int": int, "float": float, "bool": bool}
+        for flag in swivel.FLAGS.__dict__["__wrapped"].__dict__["__flags"].values():
+            parser.add_argument(
+                "--" + flag.name, default=flag.default, type=types[flag.flag_type()],
+                help=flag.help)
+except ImportError as e:
+    logging.warning("Tensorflow is not installed, dependent functionality is unavailable.")
 
-def mirror_tf_args(parser: argparse.ArgumentParser):
-    """
-    Copies the command line flags registered in swivel.py to an :class:`argparse.ArgumentParser`.
-    :param parser: object to copy flags to.
-    :return: None
-    """
-    types = {"string": str, "int": int, "float": float, "bool": bool}
-    for flag in swivel.FLAGS.__dict__["__wrapped"].__dict__["__flags"].values():
-        parser.add_argument(
-            "--" + flag.name, default=flag.default, type=types[flag.flag_type()], help=flag.help)
+    def mirror_tf_args(parser: argparse.ArgumentParser):
+        """Dummy handler to avoid errors in main."""
+        pass
 
 
 def run_swivel(args: argparse.Namespace):


### PR DESCRIPTION
Avoid import error on systems without `tensorflow`.
Signed-off-by: egor <egor@sourced.tech>