### PR TITLE
Fix pyspark version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ sourced-engine>=0.5.1,<0.6
 parquet>=1.2,<2.0
 numpy>=1.14
 humanize>=0.5.0,<0.6
-pyspark==2.2.0.post0
+pyspark>=2.2.0,<2.2.1
 pygments>=2.2.0,<3.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
                       "bblfsh>=2.2.1,<3.0",
                       "modelforge>=0.5.4-alpha",
                       "sourced-engine>=0.5.1,<0.6",
-                      "pyspark==2.2.0.post0",
+                      "pyspark>=2.2.0,<2.2.1",
                       "humanize>=0.5.0",
                       "parquet>=1.2,<2.0",
                       "pygments>=2.2.0,<3.0"] + typing,


### PR DESCRIPTION
Updated PR for https://github.com/src-d/ml/pull/186#event-1498671266
I really do not like this messages
```
pkg_resources.DistributionNotFound: The 'pyspark==2.2.0.post0' distribution was not found and is required by sourced-ml
```
:)

Now it should work