### PR TITLE
Remove pandas because to slow to install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ parquet>=1.2,<2.0
 numpy>=1.14
 humanize>=0.5.0,<0.6
 pyspark>=2.2.0,<2.2.1
-pandas>=0.22.0,<1.0
 pygments>=2.2.0,<3.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
                       "sourced-engine>=0.5.1,<0.6",
                       "pyspark>=2.2.0,<2.2.1",
                       "humanize>=0.5.0",
-                      "pandas>=0.22.0,<1.0",
                       "parquet>=1.2,<2.0",
                       "pygments>=2.2.0,<3.0"] + typing,
     extras_require={

--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -66,7 +66,7 @@ def get_parser() -> argparse.ArgumentParser:
         help="The path to the repositories.")
     repos2ids_parser.add_argument(
         "-o", "--output", required=True,
-        help="[OUT] output CSV file with identifiers.")
+        help="[OUT] output path to the CSV file with identifiers.")
     repos2ids_parser.add_argument(
         "--split", action="store_true",
         help="Enables filtering identifiers that are splittable"

--- a/sourced/ml/cmd_entries/repos2ids.py
+++ b/sourced/ml/cmd_entries/repos2ids.py
@@ -20,4 +20,9 @@ def repos2ids_entry(args):
         .execute()
 
     log.info("Writing %s", args.output)
-    ids.toDF().toPandas().to_csv(args.output)
+    ids.toDF() \
+        .coalesce(1) \
+        .write \
+        .option("header", "true") \
+        .mode("overwrite") \
+        .csv(args.output)


### PR DESCRIPTION
Signed-off-by: Waren Long <waren@sourced.tech>

`pip3 install pandas` is super slow and it could easily be removed saving the CSV file like this: