### PR TITLE
Add deployment via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
 stages:
   - test
   - name: deploy
+    # require any tag name to deploy
     if: tag =~ .*
 _install: &_install
   - gimme 1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ addons:
       - libboost-all-dev
       - libxml2-dev
       - libsnappy-dev
+stages:
+  - test
+  - name: deploy
+    if: tag =~ .*
 _install: &_install
   - gimme 1.8
   - source ~/.gimme/envs/latest.env
@@ -26,6 +30,12 @@ _install: &_install
   - pip install -e .
 _coverage: &_coverage
   - SCRIPT="coverage run --concurrency=multiprocessing -m unittest discover && coverage combine"
+_deploy: &_deploy
+  provider: script
+  script: twine upload dist/*py3-none-any* -u $PYPI_LOGIN -p $PYPI_PASS
+  skip_cleanup: true
+  on:
+    tags: true
 matrix:
   include:
     - python: 3.4
@@ -42,11 +52,20 @@ matrix:
       install: *_install
       after_success:
         - codecov
+    - stage: deploy
+      python: 3.4
+      install:
+        - pip3 install --upgrade pip
+        - pip3 install twine
+      before_script: skip
+      script:
+        - python3 setup.py bdist_wheel
+      deploy: *_deploy
   fast_finish: true
 before_script:
-- docker run -d --privileged -p 9432:9432 --name bblfshd bblfsh/bblfshd
-- docker exec -it bblfshd bblfshctl driver install --all
+  - docker run -d --privileged -p 9432:9432 --name bblfshd bblfsh/bblfshd
+  - docker exec -it bblfshd bblfshctl driver install python bblfsh/python-driver
 script:
-- (eval "$SCRIPT")
+  - (eval "$SCRIPT")
 notifications:
   email: false


### PR DESCRIPTION
The same way as in https://github.com/src-d/minhashcuda

there are 2 stages: testing, using python 3.4,5,6 and deploying. 
`python3 setup.py bdist_wheel` creates `sourced_ml-0.4.4-py3-none-any.whl` file, so there is no need to use `auditwheel` tool. 

Also I change `docker exec -it bblfshd bblfshctl driver install --all` to `docker exec -it bblfshd bblfshctl driver install python bblfsh/python-driver` because we need only one driver for testing and the error `API rate limit exceeded` inside Travis.
```
[0K$ docker exec -it bblfshd bblfshctl driver install --all
Error, GET https://api.github.com/orgs/bblfsh/repos?page=1&per_page=100&type=public: 403 API rate limit exceeded for 35.184.96.71. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 27m15s]
```