### PR TITLE
Fix locales in Dockerfile

### DIFF
--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -22,7 +22,10 @@ echo\n\' > /browser && \
     chmod +x /browser
 
 ENV BROWSER /browser
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+    dpkg-reconfigure -f noninteractive locales
 ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
 ENV PYSPARK_PYTHON python3
 ENV PYSPARK_PYTHON_DRIVER python3
 


### PR DESCRIPTION
We need to reconfigure locales. It was `C.UTF-8` (from srcd/spark:2.2.0_v2 image or its parent) and we need `en_US.UTF-8`.

To avoid such behavior:
```
docker run -it srcd/ml-core bash
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
root@491e69768462:/# env
HOSTNAME=491e69768462
TERM=xterm
spark_ver=2.2.0
LC_ALL=en_US.UTF-8
CA_CERTIFICATES_JAVA_VERSION=20140324
PYSPARK_PYTHON=python3
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin
PWD=/
hadoop_ver=2.7.3
JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
LANG=C.UTF-8
JAVA_VERSION=8u111
SHLVL=1
HOME=/root
JAVA_DEBIAN_VERSION=8u111-b14-2~bpo8+1
BROWSER=/browser
PYSPARK_PYTHON_DRIVER=python3
_=/usr/bin/env
```