### PR TITLE
Fix and extend df model dump

### DIFF
--- a/sourced/ml/models/df.py
+++ b/sourced/ml/models/df.py
@@ -49,7 +49,7 @@ class DocumentFrequencies(Model):
         return """Number of words: %d
 Random 10 words: %s
 Number of documents: %d""" % (
-            len(self._df), islice(self._df, 10), self.docs)
+            len(self._df), dict(islice(self._df.items(), 10)), self.docs)
 
     @property
     def docs(self):


### PR DESCRIPTION
now if you run `python3 -m sourced.ml dump df.asdf` you get
```
{'created_at': datetime.datetime(2018, 3, 16, 15, 7, 15, 490385),
 'dependencies': [],
 'model': 'docfreq',
 'uuid': '5337ac75-ab3d-4dc6-8a72-577da2b646a9',
 'version': [1, 0, 0]}
Number of words: 275
Random 10 words: <itertools.islice object at 0x7f6738e8ddb8>
Number of documents: 46
```

`<itertools.islice object at 0x7f6738e8ddb8>` is not what we want. 

I also add frequencies output, because it is important to see them. You will get something like:
```
{'created_at': datetime.datetime(2018, 3, 16, 15, 7, 15, 490385),
 'dependencies': [],
 'model': 'docfreq',
 'uuid': '5337ac75-ab3d-4dc6-8a72-577da2b646a9',
 'version': [1, 0, 0]}
Number of words: 275
Random 10 words: {'i.crmessag': 7.0, 'i.descript': 2.0, 'i.servic': 9.0, 'i.class': 6.0, 'i.resourc': 4.0, 'i.target': 4.0, 'i.path': 6.0, 'i.activ': 4.0, 'i.environ': 2.0, 'i.tostr': 5.0}
Number of documents: 46
```