### PR TITLE
Add sourced-engine version auto-update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ numpy>=1.14
 humanize>=0.5.0,<0.6
 pyspark>=2.2.0,<2.2.1
 pygments>=2.2.0,<3.0
+pip==9.0.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
                       "pyspark>=2.2.0,<2.2.1",
                       "humanize>=0.5.0",
                       "parquet>=1.2,<2.0",
-                      "pygments>=2.2.0,<3.0"] + typing,
+                      "pygments>=2.2.0,<3.0",
+                      "pip==9.0.1"] + typing,
     extras_require={
         "tf": ["tensorflow>=1.0,<2.0"],
         "tf_gpu": ["tensorflow-gpu>=1.0,<2.0"],

--- a/sourced/ml/utils/engine.py
+++ b/sourced/ml/utils/engine.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import pip
 
 from sourced.engine import Engine
 from sourced.ml.utils import add_spark_args, create_spark, assemble_spark_config
@@ -24,7 +25,7 @@ class EngineDefault:
     Default arguments for create_engine function and __main__
     """
     BBLFSH = "localhost"
-    VERSION = "0.5.1"
+    VERSION = {pkg.key: pkg.version for pkg in pip.get_installed_distributions()}["sourced-engine"]
 
 
 def add_engine_args(my_parser, default_packages=None):


### PR DESCRIPTION
Anyway, we should use the same versions of `sourced-engine` jar file and python module. So I add this logic to avoid mistakes. 

for now it is 0.5.3.

One thing, should we add `pip` to requirements?