### PR TITLE
Improve token parser

### DIFF
--- a/sourced/ml/algorithms/token_parser.py
+++ b/sourced/ml/algorithms/token_parser.py
@@ -70,17 +70,21 @@ class TokenParser:
 
     def split(self, token):
         token = token.strip()[:self.max_token_length]
-        prev_p = [""]
 
         def ret(name):
             r = name.lower()
             if len(name) >= self.min_split_length:
+                ret.last_subtoken = r
                 yield r
-                if prev_p[0]:
-                    yield prev_p[0] + r
-                    prev_p[0] = ""
+                if ret.prev_p:
+                    yield ret.prev_p + r
+                    ret.prev_p = ""
             else:
-                prev_p[0] = r
+                ret.prev_p = r
+                yield ret.last_subtoken + r
+                ret.last_subtoken = ""
+        ret.prev_p = ""
+        ret.last_subtoken = ""
 
         for part in self.NAME_BREAKUP_RE.split(token):
             if not part:

--- a/sourced/ml/algorithms/token_parser.py
+++ b/sourced/ml/algorithms/token_parser.py
@@ -98,8 +98,8 @@ class TokenParser:
                     pos = i
                 elif prev.isupper() and this.islower():
                     if 0 < i - 1 - pos <= 3:
-                        yield from ret(part[pos:i - 1])
-                        pos = i - 1
+                        yield from ret(part[pos:i])
+                        pos = i
                     elif i - 1 > pos:
                         yield from ret(part[pos:i])
                         pos = i

--- a/sourced/ml/tests/test_token_parser.py
+++ b/sourced/ml/tests/test_token_parser.py
@@ -9,19 +9,30 @@ class TokenParserTests(unittest.TestCase):
         self.tp = TokenParser(stem_threshold=4, max_token_length=20)
 
     def test_process_token(self):
-        self.assertEqual(
-            list(self.tp.split("set /for. *&PrintAll")),
-            ["set", "for", "print", "all"])
-        self.assertEqual(
-            list(self.tp.split("JumpDown not Here")),
-            ["jump", "down", "not", "here"])
+
         _max_token_length = self.tp.max_token_length
         self.tp.max_token_length = 100
-        self.assertEqual(list(self.tp.process_token("sourced.ml.algorithms.uast_ids_to_bag")),
-                         ["sourc", "sourcedml", "algorithm", "mlalgorithm",
-                          "uast", "ids", "idsto", "bag", "tobag"])
-        self.assertEqual(list(self.tp.process_token("a.b.c.d")), ["a", "b", "c", "d"])
 
+        tokens = [
+            ("sourced.ml.algorithms.uast_ids_to_bag",
+             ["sourc", "sourcedml", "algorithm", "mlalgorithm",
+              "uast", "ids", "idsto", "bag", "tobag"]),
+            # Bad example. Parser failed to parse it correctly
+            ("WORSTnameYOUcanIMAGINE", ['worst', 'name', 'nameyo', 'ucan', 'youcan', 'imagin']),
+            # Another bad example. Parser failed to parse it correctly
+            ("ONE_M0re_.__badId.example", ['one', 'onem', 're', 'bad', 'rebad',
+                                           'badid', 'exampl', 'idexampl']),
+            ("never_use_Such__varsableNames", ['never', 'use', 'such', 'varsabl', 'name']),
+            ("a.b.c.d", ["a", "b", "c", "d"]),
+            ("A.b.Cd.E", ['a', 'b', 'cd', 'e']),
+            ("looong_sh_loooong_sh", ['looong', 'looongsh', 'loooong', 'shloooong', 'loooongsh']),
+            ("sh_sh_sh_sh", ['sh', 'sh', 'sh', 'sh']),
+            ("loooong_loooong_loooong", ['loooong', 'loooong', 'loooong'])
+        ]
+
+        for token, correct in tokens:
+            res = list(self.tp.process_token(token))
+            self.assertEqual(res, correct)
         self.tp.max_token_length = _max_token_length
 
     def test_split(self):
@@ -34,6 +45,12 @@ class TokenParserTests(unittest.TestCase):
             list(self.tp.split("print really long line")),
             # 'longli' is expected artifact due to edge effects
             ["print", "really", "long", "longli"])
+        self.assertEqual(
+            list(self.tp.split("set /for. *&PrintAll")),
+            ["set", "for", "print", "all"])
+        self.assertEqual(
+            list(self.tp.split("JumpDown not Here")),
+            ["jump", "down", "not", "here"])
 
     def test_stem(self):
         self.assertEqual(self.tp.stem("lol"), "lol")

--- a/sourced/ml/tests/test_token_parser.py
+++ b/sourced/ml/tests/test_token_parser.py
@@ -17,9 +17,10 @@ class TokenParserTests(unittest.TestCase):
             ("sourced.ml.algorithms.uast_ids_to_bag",
              ["sourc", "sourcedml", "algorithm", "mlalgorithm",
               "uast", "ids", "idsto", "bag", "tobag"]),
-            # Bad example. Parser failed to parse it correctly
-            ("WORSTnameYOUcanIMAGINE", ['worst', 'name', 'nameyo', 'ucan', 'youcan', 'imagin']),
+            ("WORSTnameYOUcanIMAGINE", ['worst', 'name', 'you', 'can', 'imagin']),
             # Another bad example. Parser failed to parse it correctly
+            ("SmallIdsToFoOo", ["small", "ids", 'idsto', 'fo', 'oo']),
+            ("SmallIdFooo", ["small", "smallid", 'fooo', 'idfooo']),
             ("ONE_M0re_.__badId.example", ['one', 'onem', 're', 'bad', 'rebad',
                                            'badid', 'exampl', 'idexampl']),
             ("never_use_Such__varsableNames", ['never', 'use', 'such', 'varsabl', 'name']),

--- a/sourced/ml/tests/test_token_parser.py
+++ b/sourced/ml/tests/test_token_parser.py
@@ -15,6 +15,14 @@ class TokenParserTests(unittest.TestCase):
         self.assertEqual(
             list(self.tp.split("JumpDown not Here")),
             ["jump", "down", "not", "here"])
+        _max_token_length = self.tp.max_token_length
+        self.tp.max_token_length = 100
+        self.assertEqual(list(self.tp.process_token("sourced.ml.algorithms.uast_ids_to_bag")),
+                         ["sourc", "sourcedml", "algorithm", "mlalgorithm",
+                          "uast", "ids", "idsto", "bag", "tobag"])
+        self.assertEqual(list(self.tp.process_token("a.b.c.d")), ["a", "b", "c", "d"])
+
+        self.tp.max_token_length = _max_token_length
 
     def test_split(self):
         self.assertEqual(list(self.tp.split("set for")), ["set", "for"])
@@ -24,7 +32,8 @@ class TokenParserTests(unittest.TestCase):
         self.assertEqual(list(self.tp.split("PrintAllExcept")), ["print", "all", "except"])
         self.assertEqual(
             list(self.tp.split("print really long line")),
-            ["print", "really", "long"])
+            # 'longli' is expected artifact due to edge effects
+            ["print", "really", "long", "longli"])
 
     def test_stem(self):
         self.assertEqual(self.tp.stem("lol"), "lol")


### PR DESCRIPTION
- Add small subtokens not only to the next token but also to the previous:
before:
`'sourced.ml.algorithms.uast_ids_to_bag' -> ['sourc', 'algorithm', 'mlalgorithm', 'uast', 'ids', 'bag', 'tobag']`
after: 
`'sourced.ml.algorithms.uast_ids_to_bag' -> ["sourc", "sourcedml", "algorithm", "mlalgorithm", "uast", "ids", "idsto", "bag", "tobag"]`
- Add test cases
- refactor `prev_p[0]` to `ret.prev_p`