### PR TITLE
Improve XPATH for identifier extraction

### DIFF
--- a/sourced/ml/algorithms/uast_ids_to_bag.py
+++ b/sourced/ml/algorithms/uast_ids_to_bag.py
@@ -60,7 +60,7 @@ class UastIds2Bag(UastTokens2Bag):
     Converts a UAST to a bag-of-identifiers.
     """
 
-    XPATH = "//*[@roleIdentifier and not(@roleQualified)]"
+    XPATH = "//*[@roleIdentifier]"
 
     def __init__(self, token2index=None, token_parser=None):
         """


### PR DESCRIPTION
For code `a = b.c` we have next UAST:
```
#  Token  Internal Role  Roles Tree                                  
                                                                     
   ||     Module         FILE, MODULE                                
1  ||     Assign         ┣ BINARY, ASSIGNMENT, EXPRESSION            
1  |a|    Name           ┃ ┣ LEFT, IDENTIFIER, EXPRESSION            
1  |c|    Attribute      ┃ ┣ RIGHT, IDENTIFIER, EXPRESSION, QUALIFIED
1  |b|    Name           ┗ ┗ ┗ QUALIFIED, IDENTIFIER, EXPRESSION     
```
And with old XPATH we get only one identifier `a`. Now we are able to get all three.