### PR TITLE
Hot fix for literals & identifier extractors:

### DIFF
--- a/sourced/ml/algorithms/__init__.py
+++ b/sourced/ml/algorithms/__init__.py
@@ -1,5 +1,6 @@
 from sourced.ml.algorithms.tf_idf import log_tf_log_idf
 from sourced.ml.algorithms.token_parser import TokenParser, NoopTokenParser
+from sourced.ml.algorithms.uast_ids_to_bag import UastIds2Bag, uast2sequence
 from sourced.ml.algorithms.uast_struct_to_bag import UastRandomWalk2Bag, UastSeq2Bag
 from sourced.ml.algorithms.uast_inttypes_to_nodes import Uast2QuantizedChildren
 from sourced.ml.algorithms.uast_inttypes_to_graphlets import Uast2GraphletBag

--- a/sourced/ml/algorithms/uast_ids_to_bag.py
+++ b/sourced/ml/algorithms/uast_ids_to_bag.py
@@ -1,9 +1,25 @@
-from collections import defaultdict
+from collections import defaultdict, deque
 
 import bblfsh
 
 from sourced.ml.algorithms import TokenParser, NoopTokenParser
 from sourced.ml.algorithms.uast_to_bag import Uast2BagBase
+from sourced.ml.utils import IDENTIFIER
+
+
+def uast2sequence(root):
+    sequence = []
+    nodes = defaultdict(deque)
+    stack = [root]
+    nodes[id(root)].extend(root.children)
+    while stack:
+        if nodes[id(stack[-1])]:
+            child = nodes[id(stack[-1])].popleft()
+            nodes[id(child)].extend(child.children)
+            stack.append(child)
+        else:
+            sequence.append(stack.pop())
+    return sequence
 
 
 class FakeVocabulary:
@@ -70,3 +86,23 @@ class UastIds2Bag(UastTokens2Bag):
         """
         token_parser = TokenParser() if token_parser is None else token_parser
         super().__init__(token2index, token_parser)
+
+    def __call__(self, uast):
+        """
+        HOTFIX for https://github.com/bblfsh/client-python/issues/92
+        Converts a UAST to a weighed bag-of-identifiers. The weights are identifiers frequencies.
+        The tokens are preprocessed by _token_parser.
+        Overwrite __call__ to avoid issues with `bblfsh.filter`.
+
+        :param uast: The UAST root node.
+        :return: bag
+        """
+        nodes = [node for node in uast2sequence(uast) if IDENTIFIER in node.roles]
+        bag = defaultdict(int)
+        for node in nodes:
+            for sub in self._token_parser.process_token(node.token):
+                try:
+                    bag[self._token2index[sub]] += 1
+                except KeyError:
+                    continue
+        return bag

--- a/sourced/ml/algorithms/uast_struct_to_bag.py
+++ b/sourced/ml/algorithms/uast_struct_to_bag.py
@@ -1,7 +1,8 @@
 import random
-from collections import defaultdict, deque
+from collections import defaultdict
 
 from sourced.ml.algorithms.uast_ids_to_bag import FakeVocabulary, Uast2BagBase
+from sourced.ml.algorithms import uast2sequence
 
 
 class Uast2StructBagBase(Uast2BagBase):
@@ -33,23 +34,9 @@ class UastSeq2Bag(Uast2StructBagBase):
         _node2index = Node2InternalType() if node2index is None else node2index
         super().__init__(stride, seq_len, _node2index)
 
-    def _uast2sequence(self, root):
-        sequence = []
-        nodes = defaultdict(deque)
-        stack = [root]
-        nodes[id(root)].extend(root.children)
-        while stack:
-            if nodes[id(stack[-1])]:
-                child = nodes[id(stack[-1])].popleft()
-                nodes[id(child)].extend(child.children)
-                stack.append(child)
-            else:
-                sequence.append(stack.pop())
-        return sequence
-
     def __call__(self, uast):
         bag = defaultdict(int)
-        node_sequence = self._uast2sequence(uast)
+        node_sequence = uast2sequence(uast)
 
         # convert to str - requirement from wmhash.BagsExtractor
         node_sequence = [self.node2index[n] for n in node_sequence]

--- a/sourced/ml/extractors/identifiers.py
+++ b/sourced/ml/extractors/identifiers.py
@@ -12,8 +12,7 @@ class IdentifiersBagExtractor(BagsExtractor):
 
     def __init__(self, docfreq_threshold=None, split_stem=False, **kwargs):
         super().__init__(docfreq_threshold, **kwargs)
-        self.id2bag = UastIds2Bag(
-            None, NoopTokenParser() if not split_stem else None)
+        self.id2bag = UastIds2Bag(None, NoopTokenParser() if not split_stem else None)
 
     def uast_to_bag(self, uast):
         return self.id2bag(uast)

--- a/sourced/ml/extractors/literals.py
+++ b/sourced/ml/extractors/literals.py
@@ -1,8 +1,10 @@
 import codecs
+from collections import defaultdict
 import os
 
-from sourced.ml.algorithms.uast_ids_to_bag import UastIds2Bag
+from sourced.ml.algorithms import UastIds2Bag, uast2sequence
 from sourced.ml.extractors import BagsExtractor, register_extractor
+from sourced.ml.utils import LITERAL
 
 
 class HashedTokenParser:
@@ -26,6 +28,26 @@ class Literals2Bag(UastIds2Bag):
         """
         token_parser = HashedTokenParser() if token_parser is None else token_parser
         super().__init__(token2index, token_parser)
+
+    def __call__(self, uast):
+        """
+        HOTFIX for https://github.com/bblfsh/client-python/issues/92
+        Converts a UAST to a weighed bag-of-literals. The weights are literals frequencies.
+        The tokens are preprocessed by _token_parser.
+        Overwrite __call__ to avoid issues with `bblfsh.filter`.
+
+        :param uast: The UAST root node.
+        :return: bag
+        """
+        nodes = [node for node in uast2sequence(uast) if LITERAL in node.roles]
+        bag = defaultdict(int)
+        for node in nodes:
+            for sub in self._token_parser.process_token(node.token):
+                try:
+                    bag[self._token2index[sub]] += 1
+                except KeyError:
+                    continue
+        return bag
 
 
 @register_extractor

--- a/sourced/ml/utils/__init__.py
+++ b/sourced/ml/utils/__init__.py
@@ -1,4 +1,5 @@
 from sourced.ml.utils.bigartm import install_bigartm
+from sourced.ml.utils.bblfsh_roles import IDENTIFIER, QUALIFIED, LITERAL
 from sourced.ml.utils.spark import add_spark_args, create_spark, assemble_spark_config, \
     SparkDefault
 from sourced.ml.utils.engine import add_engine_args, create_engine, EngineConstants

--- a/sourced/ml/utils/bblfsh_roles.py
+++ b/sourced/ml/utils/bblfsh_roles.py
@@ -3,3 +3,4 @@ import bblfsh
 
 IDENTIFIER = bblfsh.role_id("IDENTIFIER")
 QUALIFIED = bblfsh.role_id("QUALIFIED")
+LITERAL = bblfsh.role_id("LITERAL")


### PR DESCRIPTION
* replace bblfsh.filter with simple traversal algorithm
* add traversal algorithm to utils
* add bblfsh roles

Signed-off-by: egor <egor@sourced.tech>