### PR TITLE
Move ArgumentDefaultsHelpFormatterNoNone class 

### DIFF
--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -7,22 +7,11 @@ from modelforge.logs import setup_logging
 
 from sourced.ml.cmd_entries import bigartm2asdf_entry, dump_model, projector_entry, bow2vw_entry, \
     run_swivel, postprocess_id2vec, preprocess_id2vec, repos2coocc_entry, repos2df_entry, \
-    repos2ids_entry, repos2bow_entry
+    repos2ids_entry, repos2bow_entry, ArgumentDefaultsHelpFormatterNoNone
 from sourced.ml.cmd_entries.args import add_repo2_args, add_feature_args, add_vocabulary_size_arg
 from sourced.ml.cmd_entries.repos2bow import add_bow_args
 from sourced.ml.cmd_entries.run_swivel import mirror_tf_args
 from sourced.ml.utils import install_bigartm, add_engine_args
-
-
-class ArgumentDefaultsHelpFormatterNoNone(argparse.ArgumentDefaultsHelpFormatter):
-    """
-    Pretty formatter of help message for arguments.
-    It adds default value to the end if it is not None.
-    """
-    def _get_help_string(self, action):
-        if action.default is None:
-            return action.help
-        return super()._get_help_string(action)
 
 
 def get_parser() -> argparse.ArgumentParser:

--- a/sourced/ml/cmd_entries/__init__.py
+++ b/sourced/ml/cmd_entries/__init__.py
@@ -1,3 +1,4 @@
+from sourced.ml.cmd_entries.args import ArgumentDefaultsHelpFormatterNoNone
 from sourced.ml.cmd_entries.bigartm2asdf import bigartm2asdf_entry
 from sourced.ml.cmd_entries.bow_converters import bow2vw_entry
 from sourced.ml.cmd_entries.dump_model import dump_model

--- a/sourced/ml/cmd_entries/args.py
+++ b/sourced/ml/cmd_entries/args.py
@@ -5,6 +5,17 @@ from sourced.ml import extractors
 from sourced.ml.transformers import Moder
 
 
+class ArgumentDefaultsHelpFormatterNoNone(argparse.ArgumentDefaultsHelpFormatter):
+    """
+    Pretty formatter of help message for arguments.
+    It adds default value to the end if it is not None.
+    """
+    def _get_help_string(self, action):
+        if action.default is None:
+            return action.help
+        return super()._get_help_string(action)
+
+
 def add_vocabulary_size_arg(my_parser: argparse.ArgumentParser):
     my_parser.add_argument(
         "-v", "--vocabulary-size", default=10000000, type=int,


### PR DESCRIPTION
Moved ArgumentDefaultsHelpFormatterNoNone form __main__ to sourced/ml/cmd_entries/args.py and put it into sourced/ml/cmd_entries/__init__.py