### PR TITLE
Parquet loader

### DIFF
--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -10,12 +10,11 @@ from sourced.ml.cmd_entries import bigartm2asdf_entry, dump_model, projector_ent
     run_swivel, postprocess_id2vec, preprocess_id2vec, repos2coocc_entry, repos2df_entry, \
     repos2ids_entry, repos2bow_entry, repos2roles_and_ids_entry, repos2id_distance_entry, \
     repos2id_sequence_entry
-from sourced.ml.cmd_entries.args import add_repo2_args, add_feature_args, \
-    add_vocabulary_size_arg, add_extractor_args, add_split_stem_arg, \
-    ArgumentDefaultsHelpFormatterNoNone
-from sourced.ml.cmd_entries.repos2bow import add_bow_args
+from sourced.ml.cmd_entries.args import add_df_args, add_feature_args, \
+    add_vocabulary_size_arg, add_repo2_args, add_split_stem_arg, \
+    ArgumentDefaultsHelpFormatterNoNone, add_bow_args
 from sourced.ml.cmd_entries.run_swivel import mirror_tf_args
-from sourced.ml.utils import install_bigartm, add_engine_args
+from sourced.ml.utils import install_bigartm
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -30,40 +29,34 @@ def get_parser() -> argparse.ArgumentParser:
     # Create and construct subparsers
     subparsers = parser.add_subparsers(help="Commands", dest="command")
 
-    def add_parser(name, help):
+    def add_parser(name, help_message):
         return subparsers.add_parser(
-            name, help=help, formatter_class=ArgumentDefaultsHelpFormatterNoNone)
+            name, help=help_message, formatter_class=ArgumentDefaultsHelpFormatterNoNone)
 
     # ------------------------------------------------------------------------
     repos2bow_parser = add_parser(
         "repos2bow", "Convert source code to the bag-of-words model.")
     repos2bow_parser.set_defaults(handler=repos2bow_entry)
+    add_df_args(repos2bow_parser)
     add_repo2_args(repos2bow_parser)
-    add_engine_args(repos2bow_parser)
-    add_bow_args(repos2bow_parser)
     add_feature_args(repos2bow_parser)
+    add_bow_args(repos2bow_parser)
     # ------------------------------------------------------------------------
     repos2df_parser = add_parser(
         "repos2df", "Calculate document frequencies of features extracted from source code.")
     repos2df_parser.set_defaults(handler=repos2df_entry)
+    add_df_args(repos2df_parser)
     add_repo2_args(repos2df_parser)
-    add_engine_args(repos2df_parser)
     add_feature_args(repos2df_parser)
     # ------------------------------------------------------------------------
     repos2ids_parser = subparsers.add_parser(
         "repos2ids", help="Convert source code to a bag of identifiers.")
     repos2ids_parser.set_defaults(handler=repos2ids_entry)
-    add_engine_args(repos2ids_parser)
-    repos2ids_parser.add_argument(
-        "-r", "--repositories", required=True,
-        help="The path to the repositories.")
+    add_repo2_args(repos2ids_parser)
+    add_split_stem_arg(repos2ids_parser)
     repos2ids_parser.add_argument(
         "-o", "--output", required=True,
         help="[OUT] output path to the CSV file with identifiers.")
-    repos2ids_parser.add_argument(
-        "--split", action="store_true",
-        help="Enables filtering identifiers that are splittable"
-             "based on special characters or case changes.")
     repos2ids_parser.add_argument(
         "--idfreq", action="store_true",
         help="Adds identifier frequencies to the output CSV file."
@@ -74,8 +67,8 @@ def get_parser() -> argparse.ArgumentParser:
     repos2coocc_parser = add_parser(
         "repos2coocc", "Convert source code to the sparse co-occurrence matrix of identifiers.")
     repos2coocc_parser.set_defaults(handler=repos2coocc_entry)
-    add_engine_args(repos2coocc_parser)
-    add_repo2_args(repos2coocc_parser, quant=False)
+    add_df_args(repos2coocc_parser)
+    add_repo2_args(repos2coocc_parser)
     add_split_stem_arg(repos2coocc_parser)
     repos2coocc_parser.add_argument(
         "-o", "--output", required=True,
@@ -85,8 +78,7 @@ def get_parser() -> argparse.ArgumentParser:
         "repos2roles_ids", "Converts a UAST to a list of pairs, where pair is a role and "
         "identifier. Role is merged generic roles where identifier was found.")
     repos2roles_and_ids.set_defaults(handler=repos2roles_and_ids_entry)
-    add_engine_args(repos2roles_and_ids)
-    add_extractor_args(repos2roles_and_ids)
+    add_repo2_args(repos2roles_and_ids)
     add_split_stem_arg(repos2roles_and_ids)
     repos2roles_and_ids.add_argument(
         "-o", "--output", required=True,
@@ -97,8 +89,7 @@ def get_parser() -> argparse.ArgumentParser:
         "repos2id_distance", "Converts a UAST to a list of identifier pairs "
                              "and distance between them.")
     repos2identifier_distance.set_defaults(handler=repos2id_distance_entry)
-    add_engine_args(repos2identifier_distance)
-    add_extractor_args(repos2identifier_distance)
+    add_repo2_args(repos2identifier_distance)
     add_split_stem_arg(repos2identifier_distance)
     repos2identifier_distance.add_argument(
         "-t", "--type", required=True, choices=IdentifierDistance.DistanceType.All,
@@ -115,8 +106,7 @@ def get_parser() -> argparse.ArgumentParser:
         "repos2id_sequence", "Converts a UAST to sequence of identifiers sorted by "
                              "order of appearance.")
     repos2id_sequence.set_defaults(handler=repos2id_sequence_entry)
-    add_engine_args(repos2id_sequence)
-    add_extractor_args(repos2id_sequence)
+    add_repo2_args(repos2id_sequence)
     add_split_stem_arg(repos2id_sequence)
     repos2id_sequence.add_argument(
         "--skip-docname", default=False, action="store_true",

--- a/sourced/ml/cmd_entries/args.py
+++ b/sourced/ml/cmd_entries/args.py
@@ -30,7 +30,7 @@ def add_vocabulary_size_arg(my_parser: argparse.ArgumentParser):
         help="The maximum vocabulary size.")
 
 
-def add_repo2_args(my_parser: argparse.ArgumentParser):
+def add_repo2_args(my_parser: argparse.ArgumentParser, default_packages=None):
     my_parser.add_argument(
         "-r", "--repositories", required=True,
         help="The path to the repositories.")
@@ -39,10 +39,11 @@ def add_repo2_args(my_parser: argparse.ArgumentParser):
     my_parser.add_argument(
         "--graph", help="Write the tree in Graphviz format to this file.")
     my_parser.add_argument(
-        "-l", "--languages", defaukt=all, nargs="+", choices=(
-            "Java", "Python", "JavaScript", "Ruby", "Bash"),
+        "-l", "--languages", required=True, nargs="+",
+        choices=("Java", "Python", "JavaScript", "Ruby", "Bash", "Go"),
+        default=["Java", "Python", "JavaScript", "Ruby", "Bash", "Go"],
         help="The programming languages to analyse.")
-    add_engine_args(my_parser)
+    add_engine_args(my_parser, default_packages)
 
 
 def add_df_args(my_parser: argparse.ArgumentParser):

--- a/sourced/ml/cmd_entries/args.py
+++ b/sourced/ml/cmd_entries/args.py
@@ -2,7 +2,8 @@ import argparse
 import json
 
 from sourced.ml import extractors
-from sourced.ml.transformers import Moder
+from sourced.ml.transformers import Moder, BOWWriter
+from sourced.ml.utils import add_engine_args
 
 
 class ArgumentDefaultsHelpFormatterNoNone(argparse.ArgumentDefaultsHelpFormatter):
@@ -29,38 +30,36 @@ def add_vocabulary_size_arg(my_parser: argparse.ArgumentParser):
         help="The maximum vocabulary size.")
 
 
-def add_extractor_args(my_parser: argparse.ArgumentParser):
+def add_repo2_args(my_parser: argparse.ArgumentParser):
     my_parser.add_argument(
         "-r", "--repositories", required=True,
         help="The path to the repositories.")
     my_parser.add_argument(
-        "--pause", action="store_true",
-        help="Do not terminate in the end - useful for inspecting Spark Web UI.")
-    my_parser.add_argument(
-        "-l", "--languages", required=True, nargs="+", choices=(
-            "Java", "Python", "JavaScript", "Ruby", "Bash"),
-        help="The programming languages to analyse.")
-
-
-def add_repo2_args(my_parser: argparse.ArgumentParser, quant=True):
-    add_extractor_args(my_parser)
+        "--parquet", action="store_true", help="If it's parquet input.")
     my_parser.add_argument(
         "--graph", help="Write the tree in Graphviz format to this file.")
     my_parser.add_argument(
+        "-l", "--languages", defaukt=all, nargs="+", choices=(
+            "Java", "Python", "JavaScript", "Ruby", "Bash"),
+        help="The programming languages to analyse.")
+    add_engine_args(my_parser)
+
+
+def add_df_args(my_parser: argparse.ArgumentParser):
+    my_parser.add_argument(
         "--min-docfreq", default=1, type=int,
         help="The minimum document frequency of each feature.")
-    add_vocabulary_size_arg(my_parser)
     my_parser.add_argument(
         "--docfreq", required=True,
         help="[OUT] The path to the OrderedDocumentFrequencies model.")
-    if quant:
-        my_parser.add_argument(
-            "--quant", help="[OUT] The path to the QuantizationLevels model.")
+    add_vocabulary_size_arg(my_parser)
 
 
 def add_feature_args(my_parser: argparse.ArgumentParser, required=True):
     my_parser.add_argument("-x", "--mode", choices=Moder.Options.__all__,
                            default="file", help="What to select for analysis.")
+    my_parser.add_argument(
+        "--quant", help="[OUT] The path to the QuantizationLevels model.")
     my_parser.add_argument(
         "-f", "--feature", nargs="+",
         choices=[ex.NAME for ex in extractors.__extractors__.values()],
@@ -70,3 +69,11 @@ def add_feature_args(my_parser: argparse.ArgumentParser, required=True):
             my_parser.add_argument(
                 "--%s-%s" % (ex.NAME, opt), default=val, type=json.loads,
                 help="%s's kwarg" % ex.__name__)
+
+
+def add_bow_args(my_parser: argparse.ArgumentParser):
+    my_parser.add_argument(
+        "--bow", required=True, help="[OUT] The path to the Bag-Of-Words model.")
+    my_parser.add_argument(
+        "--batch", default=BOWWriter.DEFAULT_CHUNK_SIZE, type=int,
+        help="The maximum size of a single BOW file in bytes.")

--- a/sourced/ml/cmd_entries/repos2bow.py
+++ b/sourced/ml/cmd_entries/repos2bow.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from uuid import uuid4
 
@@ -9,16 +8,6 @@ from sourced.ml.transformers import Ignition, UastExtractor, UastDeserializer, U
     Indexer, UastRow2Document, BOWWriter, Moder, LanguageSelector, create_parquet_loader
 from sourced.ml.utils import create_engine
 from sourced.ml.utils.engine import pipeline_graph, pause
-
-
-def add_bow_args(my_parser: argparse.ArgumentParser):
-    my_parser.add_argument(
-        "--bow", required=True, help="[OUT] The path to the Bag-Of-Words model.")
-    my_parser.add_argument(
-        "--batch", default=BOWWriter.DEFAULT_CHUNK_SIZE, type=int,
-        help="The maximum size of a single BOW file in bytes.")
-    my_parser.add_argument(
-        "--parquet", action="store_true", help="If it's parquet input.")
 
 
 @pause

--- a/sourced/ml/cmd_entries/repos2bow.py
+++ b/sourced/ml/cmd_entries/repos2bow.py
@@ -3,11 +3,10 @@ from uuid import uuid4
 
 from sourced.ml.extractors import create_extractors_from_args
 from sourced.ml.models import OrderedDocumentFrequencies, QuantizationLevels
-from sourced.ml.transformers import Ignition, UastExtractor, UastDeserializer, Uast2Quant, \
-    BagFeatures2DocFreq, BagFeatures2TermFreq, Uast2BagFeatures, HeadFiles, TFIDF, Cacher, \
-    Indexer, UastRow2Document, BOWWriter, Moder, LanguageSelector, create_parquet_loader
-from sourced.ml.utils import create_engine
-from sourced.ml.utils.engine import pipeline_graph, pause
+from sourced.ml.transformers import BagFeatures2DocFreq, BagFeatures2TermFreq, BOWWriter, \
+    Cacher, HeadFiles, Indexer, Moder, create_uast_source, TFIDF, UastDeserializer, \
+    UastRow2Document, Uast2Quant, Uast2BagFeatures
+from sourced.ml.utils import pause, pipeline_graph
 
 
 @pause
@@ -15,17 +14,7 @@ def repos2bow_entry_template(args, select=HeadFiles, cache_hook=None, save_hook=
     log = logging.getLogger("repos2bow")
     extractors = create_extractors_from_args(args)
     session_name = "repos2bow-%s" % uuid4()
-    if args.parquet:
-        start_point = create_parquet_loader(session_name, **args.__dict__)
-        root = start_point
-    else:
-        engine = create_engine(session_name, **args.__dict__)
-        root = engine
-
-        start_point = Ignition(engine, explain=args.explain) \
-            .link(select()) \
-            .link(LanguageSelector(languages=args.languages)) \
-            .link(UastExtractor())
+    root, start_point = create_uast_source(args, session_name, select=select)
 
     uast_extractor = start_point.link(Moder(args.mode)).link(Cacher.maybe(args.persist))
 

--- a/sourced/ml/cmd_entries/repos2bow.py
+++ b/sourced/ml/cmd_entries/repos2bow.py
@@ -6,7 +6,7 @@ from sourced.ml.extractors import create_extractors_from_args
 from sourced.ml.models import OrderedDocumentFrequencies, QuantizationLevels
 from sourced.ml.transformers import Ignition, UastExtractor, UastDeserializer, Uast2Quant, \
     BagFeatures2DocFreq, BagFeatures2TermFreq, Uast2BagFeatures, HeadFiles, TFIDF, Cacher, \
-    Indexer, UastRow2Document, BOWWriter, Moder, create_parquet_loader
+    Indexer, UastRow2Document, BOWWriter, Moder, LanguageSelector, create_parquet_loader
 from sourced.ml.utils import create_engine
 from sourced.ml.utils.engine import pipeline_graph, pause
 
@@ -35,7 +35,8 @@ def repos2bow_entry_template(args, select=HeadFiles, cache_hook=None, save_hook=
 
         start_point = Ignition(engine, explain=args.explain) \
             .link(select()) \
-            .link(UastExtractor(languages=args.languages))
+            .link(LanguageSelector(languages=args.languages)) \
+            .link(UastExtractor())
 
     uast_extractor = start_point.link(Moder(args.mode)).link(Cacher.maybe(args.persist))
 

--- a/sourced/ml/cmd_entries/repos2coocc.py
+++ b/sourced/ml/cmd_entries/repos2coocc.py
@@ -5,7 +5,7 @@ from sourced.ml.extractors import IdentifiersBagExtractor
 from sourced.ml.models import OrderedDocumentFrequencies
 from sourced.ml.transformers import Ignition, HeadFiles, UastExtractor, Cacher, UastDeserializer, \
     CooccConstructor, CooccModelSaver, BagFeatures2DocFreq, Uast2BagFeatures, Counter, \
-    UastRow2Document
+    UastRow2Document, LanguageSelector
 from sourced.ml.utils import create_engine
 from sourced.ml.utils.engine import pipeline_graph, pause
 
@@ -20,7 +20,8 @@ def repos2coocc_entry(args):
     ignition = Ignition(engine, explain=args.explain)
     uast_extractor = ignition \
         .link(HeadFiles()) \
-        .link(UastExtractor(languages=args.languages)) \
+        .link(LanguageSelector(languages=args.languages)) \
+        .link(UastExtractor()) \
         .link(UastRow2Document()) \
         .link(Cacher.maybe(args.persist))
     log.info("Extracting UASTs...")

--- a/sourced/ml/cmd_entries/repos2coocc.py
+++ b/sourced/ml/cmd_entries/repos2coocc.py
@@ -3,25 +3,21 @@ from uuid import uuid4
 
 from sourced.ml.extractors import IdentifiersBagExtractor
 from sourced.ml.models import OrderedDocumentFrequencies
-from sourced.ml.transformers import Ignition, HeadFiles, UastExtractor, Cacher, UastDeserializer, \
-    CooccConstructor, CooccModelSaver, BagFeatures2DocFreq, Uast2BagFeatures, Counter, \
-    UastRow2Document, LanguageSelector
-from sourced.ml.utils import create_engine
-from sourced.ml.utils.engine import pipeline_graph, pause
+from sourced.ml.transformers import BagFeatures2DocFreq, Cacher, CooccConstructor, \
+    CooccModelSaver, Counter, create_uast_source, UastDeserializer, UastRow2Document, \
+    Uast2BagFeatures
+from sourced.ml.utils import pause, pipeline_graph
 
 
 @pause
 def repos2coocc_entry(args):
     log = logging.getLogger("repos2coocc")
-    engine = create_engine("repos2coocc-%s" % uuid4(), **args.__dict__)
+    session_name = "repos2coocc-%s" % uuid4()
     id_extractor = IdentifiersBagExtractor(docfreq_threshold=args.min_docfreq,
-                                           split_stem=args.split_stem)
+                                           split=args.split)
+    root, start_point = create_uast_source(args, session_name)
 
-    ignition = Ignition(engine, explain=args.explain)
-    uast_extractor = ignition \
-        .link(HeadFiles()) \
-        .link(LanguageSelector(languages=args.languages)) \
-        .link(UastExtractor()) \
+    uast_extractor = start_point \
         .link(UastRow2Document()) \
         .link(Cacher.maybe(args.persist))
     log.info("Extracting UASTs...")
@@ -41,11 +37,11 @@ def repos2coocc_entry(args):
         .greatest(args.vocabulary_size) \
         .save(args.docfreq)
 
-    token2index = engine.session.sparkContext.broadcast(df_model.order)
+    token2index = root.session.sparkContext.broadcast(df_model.order)
     uast_extractor \
         .link(CooccConstructor(token2index=token2index,
                                token_parser=id_extractor.id2bag.token_parser,
                                namespace=id_extractor.NAMESPACE)) \
         .link(CooccModelSaver(args.output, df_model)) \
         .execute()
-    pipeline_graph(args, log, ignition)
+    pipeline_graph(args, log, root)

--- a/sourced/ml/cmd_entries/repos2df.py
+++ b/sourced/ml/cmd_entries/repos2df.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from sourced.ml.extractors import create_extractors_from_args
 from sourced.ml.models import OrderedDocumentFrequencies, QuantizationLevels
-from sourced.ml.transformers import Ignition, UastExtractor, UastDeserializer, \
+from sourced.ml.transformers import Ignition, UastExtractor, UastDeserializer, LanguageSelector, \
     BagFeatures2DocFreq, HeadFiles, Uast2BagFeatures, Counter, Cacher, Uast2Quant, UastRow2Document
 from sourced.ml.utils import create_engine
 from sourced.ml.utils.engine import pipeline_graph, pause
@@ -18,7 +18,8 @@ def repos2df_entry(args):
     ignition = Ignition(engine, explain=args.explain)
     uast_extractor = ignition \
         .link(HeadFiles()) \
-        .link(UastExtractor(languages=args.languages)) \
+        .link(LanguageSelector(languages=args.languages)) \
+        .link(UastExtractor()) \
         .link(UastRow2Document()) \
         .link(Cacher.maybe(args.persist))
     log.info("Extracting UASTs...")

--- a/sourced/ml/cmd_entries/repos2df.py
+++ b/sourced/ml/cmd_entries/repos2df.py
@@ -3,23 +3,19 @@ from uuid import uuid4
 
 from sourced.ml.extractors import create_extractors_from_args
 from sourced.ml.models import OrderedDocumentFrequencies, QuantizationLevels
-from sourced.ml.transformers import Ignition, UastExtractor, UastDeserializer, LanguageSelector, \
-    BagFeatures2DocFreq, HeadFiles, Uast2BagFeatures, Counter, Cacher, Uast2Quant, UastRow2Document
-from sourced.ml.utils import create_engine
-from sourced.ml.utils.engine import pipeline_graph, pause
+from sourced.ml.transformers import BagFeatures2DocFreq, Cacher, Counter, create_uast_source,\
+    UastDeserializer, UastRow2Document, Uast2BagFeatures, Uast2Quant
+from sourced.ml.utils import pause, pipeline_graph
 
 
 @pause
 def repos2df_entry(args):
     log = logging.getLogger("repos2df")
-    engine = create_engine("repos2df-%s" % uuid4(), **args.__dict__)
+    session_name = "repos2df-%s" % uuid4()
     extractors = create_extractors_from_args(args)
+    root, start_point = create_uast_source(args, session_name)
 
-    ignition = Ignition(engine, explain=args.explain)
-    uast_extractor = ignition \
-        .link(HeadFiles()) \
-        .link(LanguageSelector(languages=args.languages)) \
-        .link(UastExtractor()) \
+    uast_extractor = start_point \
         .link(UastRow2Document()) \
         .link(Cacher.maybe(args.persist))
     log.info("Extracting UASTs...")
@@ -37,4 +33,4 @@ def repos2df_entry(args):
         .execute()
     log.info("Writing %s", args.docfreq)
     OrderedDocumentFrequencies().construct(ndocs, df).save(args.docfreq)
-    pipeline_graph(args, log, ignition)
+    pipeline_graph(args, log, root)

--- a/sourced/ml/cmd_entries/repos2id_distance.py
+++ b/sourced/ml/cmd_entries/repos2id_distance.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from sourced.ml.extractors import IdentifierDistance
 from sourced.ml.transformers import Ignition, UastExtractor, UastDeserializer, \
-    HeadFiles, Uast2BagFeatures, Cacher, UastRow2Document, CsvSaver
+    HeadFiles, Uast2BagFeatures, Cacher, UastRow2Document, CsvSaver, LanguageSelector
 from sourced.ml.transformers.basic import Rower
 from sourced.ml.utils import create_engine
 from sourced.ml.utils.engine import pause
@@ -16,7 +16,8 @@ def repos2id_distance_entry(args):
 
     Ignition(engine, explain=args.explain) \
         .link(HeadFiles()) \
-        .link(UastExtractor(languages=args.languages)) \
+        .link(LanguageSelector(languages=args.languages)) \
+        .link(UastExtractor()) \
         .link(UastRow2Document()) \
         .link(Cacher.maybe(args.persist)) \
         .link(UastDeserializer()) \

--- a/sourced/ml/cmd_entries/repos2id_distance.py
+++ b/sourced/ml/cmd_entries/repos2id_distance.py
@@ -2,22 +2,19 @@ import logging
 from uuid import uuid4
 
 from sourced.ml.extractors import IdentifierDistance
-from sourced.ml.transformers import Ignition, UastExtractor, UastDeserializer, \
-    HeadFiles, Uast2BagFeatures, Cacher, UastRow2Document, CsvSaver, LanguageSelector
-from sourced.ml.transformers.basic import Rower
-from sourced.ml.utils import create_engine
-from sourced.ml.utils.engine import pause
+from sourced.ml.transformers import Cacher, CsvSaver, Rower, create_uast_source, \
+    UastDeserializer, UastRow2Document, Uast2BagFeatures
+from sourced.ml.utils import pause, pipeline_graph
 
 
 @pause
 def repos2id_distance_entry(args):
-    engine = create_engine("repos2id_distance-%s" % uuid4(), **args.__dict__)
+    log = logging.getLogger("repos2id_distance")
+    session_name = "repos2id_distance-%s" % uuid4()
     extractors = [IdentifierDistance(args.split, args.type, args.max_distance)]
+    root, start_point = create_uast_source(args, session_name)
 
-    Ignition(engine, explain=args.explain) \
-        .link(HeadFiles()) \
-        .link(LanguageSelector(languages=args.languages)) \
-        .link(UastExtractor()) \
+    start_point \
         .link(UastRow2Document()) \
         .link(Cacher.maybe(args.persist)) \
         .link(UastDeserializer()) \
@@ -27,3 +24,4 @@ def repos2id_distance_entry(args):
                                    distance=x[1]))) \
         .link(CsvSaver(args.output)) \
         .execute()
+    pipeline_graph(args, log, root)

--- a/sourced/ml/cmd_entries/repos2id_sequence.py
+++ b/sourced/ml/cmd_entries/repos2id_sequence.py
@@ -2,29 +2,24 @@ import logging
 from uuid import uuid4
 
 from sourced.ml.extractors import IdSequenceExtractor
-from sourced.ml.transformers import Ignition, UastExtractor, UastDeserializer, \
-    HeadFiles, Uast2BagFeatures, Cacher, UastRow2Document, CsvSaver, LanguageSelector
-from sourced.ml.transformers.basic import Rower
-from sourced.ml.utils import create_engine
-from sourced.ml.utils.engine import pause
+from sourced.ml.transformers import Cacher, CsvSaver, Rower, create_uast_source, \
+    UastDeserializer, UastRow2Document, Uast2BagFeatures
+from sourced.ml.utils import pause, pipeline_graph
 
 
 @pause
 def repos2id_sequence_entry(args):
-    log = logging.getLogger("repos2id_distance")
-    engine = create_engine("repos2id_distance-%s" % uuid4(), **args.__dict__)
+    log = logging.getLogger("repos2id_sequence")
+    session_name = "repos2id_distance-%s" % uuid4()
     extractors = [IdSequenceExtractor(args.split)]
+    root, start_point = create_uast_source(args, session_name)
     if not args.skip_docname:
         mapper = Rower(lambda x: dict(document=x[0][1],
                                       identifiers=x[0][0]))
     else:
         mapper = Rower(lambda x: dict(identifiers=x[0][0]))
 
-    ignition = Ignition(engine, explain=args.explain)
-    ignition \
-        .link(HeadFiles()) \
-        .link(LanguageSelector(languages=args.languages)) \
-        .link(UastExtractor()) \
+    start_point \
         .link(UastRow2Document()) \
         .link(Cacher.maybe(args.persist)) \
         .link(UastDeserializer()) \
@@ -32,3 +27,4 @@ def repos2id_sequence_entry(args):
         .link(mapper) \
         .link(CsvSaver(args.output)) \
         .execute()
+    pipeline_graph(args, log, root)

--- a/sourced/ml/cmd_entries/repos2id_sequence.py
+++ b/sourced/ml/cmd_entries/repos2id_sequence.py
@@ -1,11 +1,9 @@
 import logging
 from uuid import uuid4
 
-from pyspark import Row
-
 from sourced.ml.extractors import IdSequenceExtractor
 from sourced.ml.transformers import Ignition, UastExtractor, UastDeserializer, \
-    HeadFiles, Uast2BagFeatures, Cacher, UastRow2Document, CsvSaver
+    HeadFiles, Uast2BagFeatures, Cacher, UastRow2Document, CsvSaver, LanguageSelector
 from sourced.ml.transformers.basic import Rower
 from sourced.ml.utils import create_engine
 from sourced.ml.utils.engine import pause
@@ -25,7 +23,8 @@ def repos2id_sequence_entry(args):
     ignition = Ignition(engine, explain=args.explain)
     ignition \
         .link(HeadFiles()) \
-        .link(UastExtractor(languages=args.languages)) \
+        .link(LanguageSelector(languages=args.languages)) \
+        .link(UastExtractor()) \
         .link(UastRow2Document()) \
         .link(Cacher.maybe(args.persist)) \
         .link(UastDeserializer()) \

--- a/sourced/ml/cmd_entries/repos2ids.py
+++ b/sourced/ml/cmd_entries/repos2ids.py
@@ -2,7 +2,7 @@ import logging
 from uuid import uuid4
 
 from sourced.ml.transformers import Ignition, ContentToIdentifiers, \
-    ContentExtractor, IdentifiersToDataset, HeadFiles, Cacher, CsvSaver
+    LanguageSelector, IdentifiersToDataset, HeadFiles, Cacher, CsvSaver
 from sourced.ml.utils import create_engine
 
 
@@ -11,7 +11,7 @@ def repos2ids_entry(args):
 
     Ignition(engine) \
         .link(HeadFiles()) \
-        .link(ContentExtractor()) \
+        .link(LanguageSelector(args.language)) \
         .link(ContentToIdentifiers(args.split)) \
         .link(Cacher.maybe(args.persist)) \
         .link(IdentifiersToDataset(args.idfreq)) \

--- a/sourced/ml/cmd_entries/repos2ids.py
+++ b/sourced/ml/cmd_entries/repos2ids.py
@@ -1,19 +1,20 @@
 import logging
 from uuid import uuid4
 
-from sourced.ml.transformers import Ignition, ContentToIdentifiers, \
-    LanguageSelector, IdentifiersToDataset, HeadFiles, Cacher, CsvSaver
-from sourced.ml.utils import create_engine
+from sourced.ml.transformers import ContentToIdentifiers, CsvSaver, IdentifiersToDataset, \
+    create_uast_source
+from sourced.ml.utils import pause, pipeline_graph
 
 
+@pause
 def repos2ids_entry(args):
-    engine = create_engine("repos2ids-%s" % uuid4(), **args.__dict__)
+    log = logging.getLogger("repos2ids")
+    session_name = "repos2ids-%s" % uuid4()
+    root, start_point = create_uast_source(args, session_name, extract_uast=False)
 
-    Ignition(engine) \
-        .link(HeadFiles()) \
-        .link(LanguageSelector(args.language)) \
+    start_point \
         .link(ContentToIdentifiers(args.split)) \
-        .link(Cacher.maybe(args.persist)) \
         .link(IdentifiersToDataset(args.idfreq)) \
         .link(CsvSaver(args.output)) \
         .execute()
+    pipeline_graph(args, log, root)

--- a/sourced/ml/cmd_entries/repos2roles_and_ids.py
+++ b/sourced/ml/cmd_entries/repos2roles_and_ids.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 from sourced.ml.extractors.roles_and_ids import RolesAndIdsExtractor
 from sourced.ml.transformers import Ignition, UastExtractor, UastDeserializer, \
-    HeadFiles, Uast2BagFeatures, Cacher, UastRow2Document, CsvSaver
+    HeadFiles, Uast2BagFeatures, Cacher, UastRow2Document, CsvSaver, LanguageSelector
 from sourced.ml.transformers.basic import Rower
 from sourced.ml.utils import create_engine
 from sourced.ml.utils.engine import pause
@@ -14,7 +14,8 @@ def repos2roles_and_ids_entry(args):
 
     Ignition(engine, explain=args.explain) \
         .link(HeadFiles()) \
-        .link(UastExtractor(languages=args.languages)) \
+        .link(LanguageSelector(languages=args.languages)) \
+        .link(UastExtractor()) \
         .link(UastRow2Document()) \
         .link(Cacher.maybe(args.persist)) \
         .link(UastDeserializer()) \

--- a/sourced/ml/cmd_entries/repos2roles_and_ids.py
+++ b/sourced/ml/cmd_entries/repos2roles_and_ids.py
@@ -1,21 +1,19 @@
+import logging
 from uuid import uuid4
 
 from sourced.ml.extractors.roles_and_ids import RolesAndIdsExtractor
-from sourced.ml.transformers import Ignition, UastExtractor, UastDeserializer, \
-    HeadFiles, Uast2BagFeatures, Cacher, UastRow2Document, CsvSaver, LanguageSelector
-from sourced.ml.transformers.basic import Rower
-from sourced.ml.utils import create_engine
-from sourced.ml.utils.engine import pause
+from sourced.ml.transformers import Cacher, CsvSaver, Rower, create_uast_source, \
+    UastDeserializer, UastRow2Document, Uast2BagFeatures
+from sourced.ml.utils import pause, pipeline_graph
 
 
 @pause
 def repos2roles_and_ids_entry(args):
-    engine = create_engine("repos2roles_and_ids-%s" % uuid4(), **args.__dict__)
+    log = logging.getLogger("repos2roles_and_ids")
+    session_name = "repos2roles_and_ids-%s" % uuid4()
+    root, start_point = create_uast_source(args, session_name)
 
-    Ignition(engine, explain=args.explain) \
-        .link(HeadFiles()) \
-        .link(LanguageSelector(languages=args.languages)) \
-        .link(UastExtractor()) \
+    start_point \
         .link(UastRow2Document()) \
         .link(Cacher.maybe(args.persist)) \
         .link(UastDeserializer()) \
@@ -23,3 +21,4 @@ def repos2roles_and_ids_entry(args):
         .link(Rower(lambda x: dict(identifier=x[0][0], role=x[1]))) \
         .link(CsvSaver(args.output)) \
         .execute()
+    pipeline_graph(args, log, root)

--- a/sourced/ml/extractors/identifiers.py
+++ b/sourced/ml/extractors/identifiers.py
@@ -10,9 +10,9 @@ class IdentifiersBagExtractor(BagsExtractor):
     OPTS = {"split-stem": False}
     OPTS.update(BagsExtractor.OPTS)
 
-    def __init__(self, docfreq_threshold=None, split_stem=False, **kwargs):
+    def __init__(self, docfreq_threshold=None, split=False, **kwargs):
         super().__init__(docfreq_threshold, **kwargs)
-        self.id2bag = UastIds2Bag(None, NoopTokenParser() if not split_stem else None)
+        self.id2bag = UastIds2Bag(None, NoopTokenParser() if not split else None)
 
     def uast_to_bag(self, uast):
         return self.id2bag(uast)

--- a/sourced/ml/tests/test_content2ids.py
+++ b/sourced/ml/tests/test_content2ids.py
@@ -29,22 +29,24 @@ class Content2IdsTests(unittest.TestCase):
         content2ids = ContentToIdentifiers(split=False)
         ids2dataset = IdentifiersToDataset(idfreq=False)
         for data, result in zip(tfidf_data.datasets, tfidf_data.ids_result):
-            rdd = self.sc.sparkContext \
+            df = self.sc.sparkContext \
                 .parallelize(range(len(data["content"]))) \
                 .map(lambda x: Row(content=data["content"][x], path=str(data["file"][x]),
-                                   repository_id=str(data["document"][x]), lang=data["lang"][x]))
-            rdd_processed = content2ids(rdd)
+                                   repository_id=str(data["document"][x]), lang=data["lang"][x])) \
+                .toDF()
+            rdd_processed = content2ids(df)
             self.assertEqual(result, set(ids2dataset(rdd_processed).collect()))
 
     def test_call_split_idfreq(self):
         content2ids = ContentToIdentifiers(split=True)
         ids2dataset = IdentifiersToDataset(idfreq=True)
         for data, result in zip(tfidf_data.datasets, tfidf_data.ids_split_idfreq_result):
-            rdd = self.sc.sparkContext \
+            df = self.sc.sparkContext \
                 .parallelize(range(len(data["content"]))) \
                 .map(lambda x: Row(content=data["content"][x], path=str(data["file"][x]),
-                                   repository_id=str(data["document"][x]), lang=data["lang"][x]))
-            rdd_processed = content2ids(rdd)
+                                   repository_id=str(data["document"][x]), lang=data["lang"][x])) \
+                .toDF()
+            rdd_processed = content2ids(df)
             self.assertEqual(result, set(ids2dataset(rdd_processed).collect()))
 
     def test_process_row_split(self):

--- a/sourced/ml/transformers/__init__.py
+++ b/sourced/ml/transformers/__init__.py
@@ -1,6 +1,6 @@
 from sourced.ml.transformers.basic import Sampler, Collector, First, Identity, Cacher, Ignition, \
     HeadFiles, UastExtractor, FieldsSelector, ParquetSaver, ParquetLoader, UastDeserializer, \
-    Counter, create_parquet_loader, CsvSaver
+    Counter, create_parquet_loader, CsvSaver, LanguageSelector
 from sourced.ml.transformers.indexer import Indexer
 from sourced.ml.transformers.tfidf import TFIDF
 from sourced.ml.transformers.transformer import Transformer
@@ -8,8 +8,7 @@ from sourced.ml.transformers.uast2bag_features import Uast2BagFeatures, UastRow2
 from sourced.ml.transformers.uast2quant import Uast2Quant
 from sourced.ml.transformers.bag_features2docfreq import BagFeatures2DocFreq
 from sourced.ml.transformers.bag_features2termfreq import BagFeatures2TermFreq
-from sourced.ml.transformers.content2ids import ContentToIdentifiers, IdentifiersToDataset, \
-    ContentExtractor
+from sourced.ml.transformers.content2ids import ContentToIdentifiers, IdentifiersToDataset
 from sourced.ml.transformers.coocc import CooccConstructor, CooccModelSaver
 from sourced.ml.transformers.bow_writer import BOWWriter
 from sourced.ml.transformers.moder import Moder

--- a/sourced/ml/transformers/__init__.py
+++ b/sourced/ml/transformers/__init__.py
@@ -1,6 +1,6 @@
-from sourced.ml.transformers.basic import Sampler, Collector, First, Identity, Cacher, Ignition, \
-    HeadFiles, UastExtractor, FieldsSelector, ParquetSaver, ParquetLoader, UastDeserializer, \
-    Counter, create_parquet_loader, CsvSaver, LanguageSelector
+from sourced.ml.transformers.basic import Cacher,  Collector, Counter, CsvSaver, FieldsSelector, \
+    First, HeadFiles, Identity, Ignition, LanguageSelector, ParquetLoader, ParquetSaver, Rower, \
+    create_uast_source, Sampler, UastDeserializer, UastExtractor
 from sourced.ml.transformers.indexer import Indexer
 from sourced.ml.transformers.tfidf import TFIDF
 from sourced.ml.transformers.transformer import Transformer

--- a/sourced/ml/transformers/basic.py
+++ b/sourced/ml/transformers/basic.py
@@ -6,7 +6,7 @@ from pyspark.sql import DataFrame
 
 from sourced.ml.transformers.transformer import Transformer
 from sourced.ml.transformers.uast2bag_features import Uast2BagFeatures
-from sourced.ml.utils import EngineConstants, assemble_spark_config, create_spark
+from sourced.ml.utils import assemble_spark_config, create_engine, create_spark, EngineConstants
 
 
 class CsvSaver(Transformer):
@@ -190,17 +190,6 @@ class ParquetLoader(Transformer):
         raise ValueError
 
 
-def create_parquet_loader(session_name, repositories, config=None, memory="", packages=None,
-                          **spark_kwargs):
-    config, packages = assemble_spark_config(config=config, packages=packages, memory=memory)
-    session = create_spark(session_name, config=config, packages=packages,
-                           **spark_kwargs)
-    log = logging.getLogger("parquet")
-    log.info("Initializing on %s", repositories)
-    parquet = ParquetLoader(session, repositories)
-    return parquet
-
-
 class UastDeserializer(Transformer):
     def __setstate__(self, state):
         super().__setstate__(state)
@@ -222,3 +211,28 @@ class UastDeserializer(Transformer):
                 self._log.error("\nBabelfish Error: Failed to parse uast for document %s for uast "
                                 "#%s" % (row[Uast2BagFeatures.Columns.document], i))
         yield Row(**row_dict)
+
+
+def create_parquet_loader(session_name, repositories, config=None, memory="", packages=None,
+                          **spark_kwargs):
+    config, packages = assemble_spark_config(config=config, packages=packages, memory=memory)
+    session = create_spark(session_name, config=config, packages=packages,
+                           **spark_kwargs)
+    log = logging.getLogger("parquet")
+    log.info("Initializing on %s", repositories)
+    parquet = ParquetLoader(session, repositories)
+    return parquet
+
+
+def create_uast_source(args, session_name, extract_uast=True, select=HeadFiles):
+    if args.parquet:
+        start_point = create_parquet_loader(session_name, **args.__dict__)
+        root = start_point
+    else:
+        root = create_engine(session_name, **args.__dict__)
+        start_point = Ignition(root, explain=args.explain) \
+            .link(select()) \
+            .link(LanguageSelector(languages=args.languages))
+        if extract_uast:
+            start_point = start_point.link(UastExtractor())
+    return root, start_point

--- a/sourced/ml/transformers/content2ids.py
+++ b/sourced/ml/transformers/content2ids.py
@@ -7,7 +7,7 @@ import pygments
 from pygments.formatter import Formatter
 from pygments.lexers import get_lexer_by_name, ClassNotFound
 from pyspark import RDD, Row
-from pyspark.sql import functions
+from pyspark.sql import DataFrame
 
 from sourced.ml.algorithms import TokenParser
 from sourced.ml.transformers import Transformer
@@ -36,8 +36,8 @@ class ContentToIdentifiers(Transformer):
         self.linguist2pygments = self.build_mapping()
         self.split = split
 
-    def __call__(self, rows: RDD):
-        return rows.flatMap(self.process_row)
+    def __call__(self, rows: DataFrame):
+        return rows.rdd.flatMap(self.process_row)
 
     def process_row(self, row: Row):
         self.names = []
@@ -146,17 +146,3 @@ class IdentifiersToDataset(Transformer):
             .map(lambda x: Row(
                     token=x,
                     token_split=" ".join(TokenParser(min_split_length=1).split(x))))
-
-
-class ContentExtractor(Transformer):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    def __call__(self, files: RDD):
-        return files \
-            .dropDuplicates(("blob_id",)) \
-            .filter("is_binary = 'false'") \
-            .classify_languages() \
-            .filter("lang is not null") \
-            .where(functions.length(functions.col("content")) > 0) \
-            .rdd

--- a/sourced/ml/utils/__init__.py
+++ b/sourced/ml/utils/__init__.py
@@ -1,6 +1,7 @@
 from sourced.ml.utils.bigartm import install_bigartm
-from sourced.ml.utils.bblfsh_roles import IDENTIFIER, QUALIFIED, LITERAL
-from sourced.ml.utils.spark import add_spark_args, create_spark, assemble_spark_config, \
+from sourced.ml.utils.bblfsh_roles import IDENTIFIER, LITERAL, QUALIFIED
+from sourced.ml.utils.spark import add_spark_args, assemble_spark_config, create_spark, \
     SparkDefault
-from sourced.ml.utils.engine import add_engine_args, create_engine, EngineConstants
+from sourced.ml.utils.engine import add_engine_args, create_engine, EngineConstants, pause, \
+    pipeline_graph
 from sourced.ml.utils.pickleable_logger import PickleableLogger

--- a/sourced/ml/utils/engine.py
+++ b/sourced/ml/utils/engine.py
@@ -3,7 +3,7 @@ import logging
 import pip
 
 from sourced.engine import Engine
-from sourced.ml.utils import add_spark_args, create_spark, assemble_spark_config
+from sourced.ml.utils.spark import add_spark_args, create_spark, assemble_spark_config
 
 
 class EngineConstants:

--- a/sourced/ml/utils/spark.py
+++ b/sourced/ml/utils/spark.py
@@ -52,6 +52,9 @@ def add_spark_args(my_parser, default_packages=None):
     my_parser.add_argument(
         "--persist", default=None, choices=persistences,
         help="Spark persistence type (StorageLevel.*).")
+    my_parser.add_argument(
+        "--pause", action="store_true",
+        help="Do not terminate in the end - useful for inspecting Spark Web UI.")
 
 
 def create_spark(session_name,


### PR DESCRIPTION
Based of [PR 222](https://github.com/src-d/ml/pull/222), should not be merged before it

- Added language selection to `repo2id`. Since it already had transformers a bit redundant with `UastExtractor` I split it, in order to get rid of `ContentExtractor` class
- Modified the parsers (was a bit of a mess so i rearranged them to have as little as possible). Among other things i put a default language flag (to all), put pause flag in `add_spark`, modified `add_repo` and `add_features`
- Added parquet loader, pause and graph to all `repo2` commands 