### PR TITLE
Move pause arg to spark parser, add pause to repos2id

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ numpy>=1.14
 humanize>=0.5.0,<0.6
 pyspark>=2.2.0,<2.2.1
 pygments>=2.2.0,<3.0
-pip!=9.0.2

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,7 @@ setup(
                       "pyspark>=2.2.0,<2.2.1",
                       "humanize>=0.5.0",
                       "parquet>=1.2,<2.0",
-                      "pygments>=2.2.0,<3.0",
-                      "pip!=9.0.2"] + typing,
+                      "pygments>=2.2.0,<3.0"] + typing,
     extras_require={
         "tf": ["tensorflow>=1.0,<2.0"],
         "tf_gpu": ["tensorflow-gpu>=1.0,<2.0"],

--- a/sourced/ml/cmd_entries/args.py
+++ b/sourced/ml/cmd_entries/args.py
@@ -34,9 +34,6 @@ def add_extractor_args(my_parser: argparse.ArgumentParser):
         "-r", "--repositories", required=True,
         help="The path to the repositories.")
     my_parser.add_argument(
-        "--pause", action="store_true",
-        help="Do not terminate in the end - useful for inspecting Spark Web UI.")
-    my_parser.add_argument(
         "-l", "--languages", required=True, nargs="+", choices=(
             "Java", "Python", "JavaScript", "Ruby", "Bash"),
         help="The programming languages to analyse.")

--- a/sourced/ml/cmd_entries/repos2ids.py
+++ b/sourced/ml/cmd_entries/repos2ids.py
@@ -1,11 +1,12 @@
-import logging
 from uuid import uuid4
 
 from sourced.ml.transformers import Ignition, ContentToIdentifiers, \
     ContentExtractor, IdentifiersToDataset, HeadFiles, Cacher, CsvSaver
 from sourced.ml.utils import create_engine
+from sourced.ml.utils.engine import pause
 
 
+@pause
 def repos2ids_entry(args):
     engine = create_engine("repos2ids-%s" % uuid4(), **args.__dict__)
 

--- a/sourced/ml/utils/engine.py
+++ b/sourced/ml/utils/engine.py
@@ -3,7 +3,7 @@ import logging
 import pip
 
 from sourced.engine import Engine
-from sourced.ml.utils import add_spark_args, create_spark, assemble_spark_config
+from sourced.ml.utils.spark import add_spark_args, assemble_spark_config, create_spark
 
 
 class EngineConstants:

--- a/sourced/ml/utils/engine.py
+++ b/sourced/ml/utils/engine.py
@@ -1,7 +1,6 @@
 import functools
 import logging
-import pip
-
+from pkg_resources import get_distribution
 from sourced.engine import Engine
 from sourced.ml.utils.spark import add_spark_args, assemble_spark_config, create_spark
 
@@ -25,7 +24,7 @@ class EngineDefault:
     Default arguments for create_engine function and __main__
     """
     BBLFSH = "localhost"
-    VERSION = {pkg.key: pkg.version for pkg in pip.get_installed_distributions()}["sourced-engine"]
+    VERSION = get_distribution("sourced-engine").version
 
 
 def add_engine_args(my_parser, default_packages=None):

--- a/sourced/ml/utils/spark.py
+++ b/sourced/ml/utils/spark.py
@@ -52,6 +52,9 @@ def add_spark_args(my_parser, default_packages=None):
     my_parser.add_argument(
         "--persist", default=None, choices=persistences,
         help="Spark persistence type (StorageLevel.*).")
+    my_parser.add_argument(
+        "--pause", action="store_true",
+        help="Do not terminate in the end - useful for inspecting Spark Web UI.")
 
 
 def create_spark(session_name,


### PR DESCRIPTION
First part of split of [old PR](https://github.com/src-d/ml/pull/223/files), moving pause to the spark args parser. It seems more logical, given we will only use in conjunction with spark.

This also takes out pip of imports: since version 10, we need new way to get engine version. Now using `pkg_ressources` to do it