### PR TITLE
Fix: Add try/except to VERSION detection

### DIFF
--- a/sourced/ml/tests/test_engine.py
+++ b/sourced/ml/tests/test_engine.py
@@ -1,0 +1,17 @@
+import unittest
+
+from sourced.ml.utils.engine import add_bblfsh_dependencies, add_engine_dependencies
+
+
+class EngineTests(unittest.TestCase):
+    def test_bblfsh_dependencies(self):
+        config = []
+        add_bblfsh_dependencies("localhost", config)
+        self.assertEqual(config, ["spark.tech.sourced.bblfsh.grpc.host=localhost"])
+
+    def test_engine_dependencies(self):
+        config = []
+        packages = []
+        add_engine_dependencies("latest", config, packages)
+        self.assertEqual(config, ["spark.tech.sourced.engine.cleanup.skip=false"])
+        self.assertEqual(packages, ["tech.sourced:engine:latest"])

--- a/sourced/ml/utils/engine.py
+++ b/sourced/ml/utils/engine.py
@@ -1,6 +1,6 @@
 import functools
 import logging
-from pkg_resources import get_distribution
+from pkg_resources import get_distribution, DistributionNotFound
 from sourced.engine import Engine
 from sourced.ml.utils.spark import add_spark_args, assemble_spark_config, create_spark
 
@@ -24,7 +24,10 @@ class EngineDefault:
     Default arguments for create_engine function and __main__
     """
     BBLFSH = "localhost"
-    VERSION = get_distribution("sourced-engine").version
+    try:
+        VERSION = get_distribution("sourced-engine").version
+    except DistributionNotFound:
+        VERSION = "0.5.7"
 
 
 def add_engine_args(my_parser, default_packages=None):

--- a/sourced/ml/utils/engine.py
+++ b/sourced/ml/utils/engine.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import requests
 from pkg_resources import get_distribution, DistributionNotFound
 from sourced.engine import Engine
 from sourced.ml.utils.spark import add_spark_args, assemble_spark_config, create_spark
@@ -19,22 +20,11 @@ class EngineConstants:
         Uast = "uast"
 
 
-class EngineDefault:
-    """
-    Default arguments for create_engine function and __main__
-    """
-    BBLFSH = "localhost"
-    try:
-        VERSION = get_distribution("sourced-engine").version
-    except DistributionNotFound:
-        VERSION = "0.5.7"
-
-
 def add_engine_args(my_parser, default_packages=None):
     add_spark_args(my_parser, default_packages=default_packages)
-    my_parser.add_argument("--bblfsh", default=EngineDefault.BBLFSH,
+    my_parser.add_argument("--bblfsh", default=None,
                            help="Babelfish server's address.")
-    my_parser.add_argument("--engine", default=EngineDefault.VERSION,
+    my_parser.add_argument("--engine", default=None,
                            help="source{d} engine version.")
     my_parser.add_argument("--repository-format", default="siva",
                            help="Repository storage input format.")
@@ -42,8 +32,9 @@ def add_engine_args(my_parser, default_packages=None):
                            help="Print the PySpark execution plans.")
 
 
-def add_engine_dependencies(engine=EngineDefault.VERSION, config=None, packages=None):
-    config.append("spark.tech.sourced.engine.cleanup.skip=true")
+def add_engine_dependencies(engine, config=None, packages=None):
+    # to clean up unpacked Siva files, see https://github.com/src-d/engine/issues/348
+    config.append("spark.tech.sourced.engine.cleanup.skip=false")
     packages.append("tech.sourced:engine:" + engine)
 
 
@@ -52,10 +43,21 @@ def add_bblfsh_dependencies(bblfsh, config=None):
 
 
 def create_engine(session_name, repositories,
-                  bblfsh=EngineDefault.BBLFSH,
-                  engine=EngineDefault.VERSION,
+                  bblfsh=None,
+                  engine=None,
                   config=None, packages=None, memory="",
                   repository_format="siva", **spark_kwargs):
+    if not bblfsh:
+        bblfsh = "localhost"
+    if not engine:
+        try:
+            engine = get_distribution("sourced-engine").version
+        except DistributionNotFound:
+            log = logging.getLogger("engine_version")
+            engine = requests.get("https://api.github.com/repos/src-d/engine/releases/latest") \
+                .json()["tag_name"].replace("v", "")
+            log.warning("Engine not found, queried GitHub to get the latest release tag (%s)",
+                        engine)
     config, packages = assemble_spark_config(config=config, packages=packages, memory=memory)
     add_engine_dependencies(engine=engine, config=config, packages=packages)
     add_bblfsh_dependencies(bblfsh=bblfsh, config=config)

--- a/sourced/ml/utils/spark.py
+++ b/sourced/ml/utils/spark.py
@@ -63,8 +63,7 @@ def create_spark(session_name,
                  config=SparkDefault.CONFIG,
                  packages=SparkDefault.PACKAGES,
                  spark_log_level=SparkDefault.LOG_LEVEL,
-                 dep_zip=False,
-                 **_):  # **kwargs are discarded for convenience
+                 dep_zip=False):  # **kwargs are discarded for convenience
     log = logging.getLogger("spark")
     log.info("Starting %s on %s", session_name, spark)
     builder = SparkSession.builder.master(spark).appName(session_name)


### PR DESCRIPTION
Simple PR to add a `try`/`except` block in the engine version detection, and default to "0.5.7" if the engine is not detected. This solves a very dumb bug that happens when using Spark in Cluster mode with `ml`, that I describe below. I had not seen it until now because I was replacing this detection with the appropriate `engine` version, e.g. `VERSION = "0.5.7"`, due to a different bug (something to do with `pip` version 9.2). Since with version 10 of `pip` we now use `pkg_ressources` to detect the `engine` version, I updated the detection and the bug popped up.

**Bug description:** 

When using `ml` with Spark in Cluster mode, we zip `ml` and `engine` then add the zip via `addPyFile` to each worker. If this is not done, our tasks fail, given workers do not have `ml` and `engine` installed. This means that neither `pip` nor `pkg_ressources` can detect ml/engine from within the workers, which is problematic because in `sourced/ml/utils/engine.py` that is exactly what we try to do in order to detect the engine version.

Now the annoying thing is that we detect the engine version to specify the correct `engine` jar to be passed to the workers, but once inside the workers there is no need to do so. However, when running jobs this still happens, probably due to some import that leads the worker to check out `sourced/ml/utils/engine.py`, which raises a `DistributionNotFound` error.

This will solve the error by defaulting to a possibly fake engine version, which in all cases will not be used. It is not problematic because if the `engine` is not present, since we still do `from sourced.engine import Engine` in the same file, we will get an `ImportError`.