### PR TITLE
Caching PR and fix for batches

### DIFF
--- a/sourced/ml/cmd_entries/repos2bow.py
+++ b/sourced/ml/cmd_entries/repos2bow.py
@@ -33,8 +33,7 @@ def repos2bow_entry_template(args, select=HeadFiles, cache_hook=None, save_hook=
         log.info("Writing quantization levels to %s", args.quant)
         QuantizationLevels().construct(quant.levels).save(args.quant)
     uast_extractor = uast_extractor \
-        .link(Uast2BagFeatures(extractors)) \
-        .link(Cacher.maybe(args.persist))
+        .link(Uast2BagFeatures(extractors))
     log.info("Calculating the document frequencies...")
     df = uast_extractor.link(BagFeatures2DocFreq()).execute()
     log.info("Writing docfreq to %s", args.docfreq)

--- a/sourced/ml/cmd_entries/repos2id_distance.py
+++ b/sourced/ml/cmd_entries/repos2id_distance.py
@@ -17,7 +17,6 @@ def repos2id_distance_entry(args):
 
     start_point \
         .link(UastRow2Document()) \
-        .link(Cacher.maybe(args.persist)) \
         .link(UastDeserializer()) \
         .link(Uast2BagFeatures(extractors)) \
         .link(Rower(lambda x: dict(identifier1=x[0][0][0],

--- a/sourced/ml/cmd_entries/repos2id_sequence.py
+++ b/sourced/ml/cmd_entries/repos2id_sequence.py
@@ -2,7 +2,7 @@ import logging
 from uuid import uuid4
 
 from sourced.ml.extractors import IdSequenceExtractor
-from sourced.ml.transformers import UastDeserializer, Uast2BagFeatures, Cacher, UastRow2Document, \
+from sourced.ml.transformers import UastDeserializer, Uast2BagFeatures, UastRow2Document, \
     CsvSaver, create_uast_source
 from sourced.ml.transformers.basic import Rower
 from sourced.ml.utils.engine import pipeline_graph, pause
@@ -21,7 +21,6 @@ def repos2id_sequence_entry(args):
         mapper = Rower(lambda x: dict(identifiers=x[0][0]))
     start_point \
         .link(UastRow2Document()) \
-        .link(Cacher.maybe(args.persist)) \
         .link(UastDeserializer()) \
         .link(Uast2BagFeatures(extractors)) \
         .link(mapper) \

--- a/sourced/ml/cmd_entries/repos2ids.py
+++ b/sourced/ml/cmd_entries/repos2ids.py
@@ -2,7 +2,7 @@ import logging
 from uuid import uuid4
 
 from sourced.ml.transformers import ContentToIdentifiers, create_uast_source, LanguageSelector, \
-    IdentifiersToDataset, Cacher, CsvSaver
+    IdentifiersToDataset, CsvSaver
 from sourced.ml.utils.engine import pipeline_graph, pause
 
 
@@ -15,7 +15,6 @@ def repos2ids_entry(args):
                                            extract_uast=False)
     start_point \
         .link(ContentToIdentifiers(args.split)) \
-        .link(Cacher.maybe(args.persist)) \
         .link(IdentifiersToDataset(args.idfreq)) \
         .link(CsvSaver(args.output)) \
         .execute()

--- a/sourced/ml/cmd_entries/repos2roles_and_ids.py
+++ b/sourced/ml/cmd_entries/repos2roles_and_ids.py
@@ -2,7 +2,7 @@ import logging
 from uuid import uuid4
 
 from sourced.ml.extractors.roles_and_ids import RolesAndIdsExtractor
-from sourced.ml.transformers import UastDeserializer, Uast2BagFeatures, Cacher, UastRow2Document, \
+from sourced.ml.transformers import UastDeserializer, Uast2BagFeatures, UastRow2Document, \
     CsvSaver, create_uast_source
 from sourced.ml.transformers.basic import Rower
 from sourced.ml.utils.engine import pipeline_graph, pause
@@ -16,7 +16,6 @@ def repos2roles_and_ids_entry(args):
 
     start_point \
         .link(UastRow2Document()) \
-        .link(Cacher.maybe(args.persist)) \
         .link(UastDeserializer()) \
         .link(Uast2BagFeatures([RolesAndIdsExtractor(args.split)])) \
         .link(Rower(lambda x: dict(identifier=x[0][0], role=x[1]))) \

--- a/sourced/ml/transformers/bow_writer.py
+++ b/sourced/ml/transformers/bow_writer.py
@@ -61,6 +61,9 @@ class BOWWriter(Transformer):
         self._log.info("Writing files to %s", self.filename)
         for i, part in enumerate(it):
             docs = [doc_index_to_name[p[0]] for p in part]
+            if not len(docs):
+                self._log.info("Batch %d is empty, skipping.", i + 1)
+                continue
             size = sum(len(p[1]) for p in part)
             data = numpy.zeros(size, dtype=numpy.float32)
             indices = numpy.zeros(size, dtype=numpy.int32)


### PR DESCRIPTION
This PR has 3 components:

- **FIX for batches:** I kept having a bug when writing batches of bags, turns out some of the partitions where empty, which caused a bug in modelforge -> to solve this added a condition to skip the batch if it is empty in the loop over the iterator, in `transformers/bow_writer.py`
- **Remove unused caching in `repos2ids`, `repos2id_distance`, `repos2id_sequence` and `repo2roles_and_ids`:** the caching is simply of no use here, since the spark job is a single series of transformation
- **Remove caching in `repos2bow`:** the caching here actually breaks stuff when the data is too massive. I know it speeds up the process, since we don't have to repeat this phase of the pipe twice: ` UastRow2Document -> UastDeserializer -> Uast2BagFeatures`, *however* the amount of data created at this point is really enormous, which makes caching slower then recomputation because most of the data has to be accessed from disk. also had some bugs where the partitions would be spilled to disk during later stages, which caused stages and then the job to fail

NB: for an example of the amount of data for bags, on 1G of parquet files the cached amount was ~20G