### PR TITLE
Fix --max-distance parameter type

### DIFF
--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -95,7 +95,7 @@ def get_parser() -> argparse.ArgumentParser:
         "-t", "--type", required=True, choices=IdentifierDistance.DistanceType.All,
         help="Distance type.")
     repos2identifier_distance.add_argument(
-        "--max-distance", default=IdentifierDistance.DEFAULT_MAX_DISTANCE,
+        "--max-distance", default=IdentifierDistance.DEFAULT_MAX_DISTANCE, type=int,
         help="Maximum distance to save.")
     repos2identifier_distance.add_argument(
         "-o", "--output", required=True,


### PR DESCRIPTION
While reviewing recent changes in sourced-ml I mentioned that `--max-distance` parameter type was removed accidentally (here: https://github.com/src-d/ml/pull/240/commits/b142e744ce7482f2a2203bf5938bccb5865bcea2#diff-d05e2f6dc6e4e4be28459a2621694d25L107).

So, I restore justice.

Signed-off-by: konstantin <kslavnov@gmail.com>