### PR TITLE
Fix `Random` to `First` in DocumentFrequencies.dump()

### DIFF
--- a/sourced/ml/models/df.py
+++ b/sourced/ml/models/df.py
@@ -47,7 +47,7 @@ class DocumentFrequencies(Model):
 
     def dump(self):
         return """Number of words: %d
-Random 10 words: %s
+First 10 words: %s
 Number of documents: %d""" % (
             len(self._df), dict(islice(self._df.items(), 10)), self.docs)
 

--- a/sourced/ml/tests/test_dump.py
+++ b/sourced/ml/tests/test_dump.py
@@ -42,7 +42,7 @@ First 10 words: ['get', 'name', 'type', 'string', 'class', 'set', 'data', 'value
  'uuid': 'f64bacd4-67fb-4c64-8382-399a8e7db52a',
  'version': [0, 1, 0]}
 Number of words: 982
-""" + "Random 10 words: "
+""" + "First 10 words: "
 
     BOW_DUMP = """{'created_at': datetime.datetime(2018, 1, 18, 21, 59, 59, 200818),
  'dependencies': [{'created_at': datetime.datetime(2018, 1, 18, 21, 59, 48, 828287),


### PR DESCRIPTION
I noticed that we have First 10 identifiers output in code, but the title says it is random.
So I have two ways to solve it:
1. Make random in both places.
2. Make first in both places.

I decide to choose the 2nd option. I think it is better and easier to compare models or track model changes after modifications.