### PR TITLE
Add subcommand to merge Document Frequencies model

### DIFF
--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -9,9 +9,10 @@ from sourced.ml.extractors import IdentifierDistance
 from sourced.ml.cmd import bigartm2asdf_entry, dump_model, projector_entry, bow2vw_entry, \
     run_swivel, postprocess_id2vec, preprocess_id2vec, repos2coocc_entry, repos2df_entry, \
     repos2ids_entry, repos2bow_entry, repos2roles_and_ids_entry, repos2id_distance_entry, \
-    repos2id_sequence_entry
+    repos2id_sequence_entry, merge_df_entry
 from sourced.ml.cmd.args import add_df_args, add_feature_args, add_split_stem_arg, \
-    add_repo2_args, add_bow_args, add_repartitioner_arg, ArgumentDefaultsHelpFormatterNoNone
+    add_vocabulary_size_arg, add_repo2_args, add_bow_args, add_repartitioner_arg, add_filter_arg, \
+    add_min_docfreq, ArgumentDefaultsHelpFormatterNoNone
 from sourced.ml.cmd.run_swivel import mirror_tf_args
 from sourced.ml.utils import install_bigartm
 
@@ -186,6 +187,22 @@ def get_parser() -> argparse.ArgumentParser:
         "input", help="Path to the model file, URL or UUID.")
     dump_parser.add_argument("--gcs", default=None, dest="gcs_bucket",
                              help="GCS bucket to use.")
+    # ------------------------------------------------------------------------
+    merge_df = add_parser("merge-df", "Merge DocumentFrequency models to a singe one.")
+    merge_df.set_defaults(handler=merge_df_entry)
+    add_filter_arg(merge_df)
+    add_min_docfreq(merge_df)
+    add_vocabulary_size_arg(merge_df)
+    merge_df.add_argument(
+        "-o", "--output", required=True,
+        help="Path to the merged document frequencies model.")
+    merge_df.add_argument(
+        "-i", "--input", required=True,
+        help="Directory to scan recursively for asdf files.")
+    merge_df.add_argument(
+        "--ordered", action="store_true", default=False,
+        help="Save OrderedDocumentFrequencies. "
+             "If not specified DocumentFrequency model will be saved")
 
     return parser
 

--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -188,21 +188,22 @@ def get_parser() -> argparse.ArgumentParser:
     dump_parser.add_argument("--gcs", default=None, dest="gcs_bucket",
                              help="GCS bucket to use.")
     # ------------------------------------------------------------------------
-    merge_df = add_parser("merge-df", "Merge DocumentFrequency models to a singe one.")
+    merge_df = add_parser("merge-df", "Merge DocumentFrequencies models to a singe one.")
     merge_df.set_defaults(handler=merge_df_entry)
     add_filter_arg(merge_df)
     add_min_docfreq(merge_df)
     add_vocabulary_size_arg(merge_df)
     merge_df.add_argument(
         "-o", "--output", required=True,
-        help="Path to the merged document frequencies model.")
+        help="Path to the merged DocumentFrequencies model.")
     merge_df.add_argument(
-        "-i", "--input", required=True,
-        help="Directory to scan recursively for asdf files.")
+        "-i", "--input", required=True, nargs="+",
+        help="DocumentFrequencies models input files."
+             "Use `-i -` to read input files from stdin.")
     merge_df.add_argument(
         "--ordered", action="store_true", default=False,
         help="Save OrderedDocumentFrequencies. "
-             "If not specified DocumentFrequency model will be saved")
+             "If not specified DocumentFrequencies model will be saved")
 
     return parser
 

--- a/sourced/ml/cmd/__init__.py
+++ b/sourced/ml/cmd/__init__.py
@@ -2,6 +2,7 @@ from sourced.ml.cmd.args import ArgumentDefaultsHelpFormatterNoNone
 from sourced.ml.cmd.bigartm2asdf import bigartm2asdf_entry
 from sourced.ml.cmd.bow_converters import bow2vw_entry
 from sourced.ml.cmd.dump_model import dump_model
+from sourced.ml.cmd.merge_df import merge_df_entry
 from sourced.ml.cmd.postprocess_id2vec import postprocess_id2vec
 from sourced.ml.cmd.preprocess_id2vec import preprocess_id2vec
 from sourced.ml.cmd.projector_entry import projector_entry

--- a/sourced/ml/cmd/args.py
+++ b/sourced/ml/cmd/args.py
@@ -1,9 +1,17 @@
 import argparse
 import json
+import logging
+from pathlib import Path
+from typing import Optional
+import sys
+
 
 from sourced.ml import extractors
 from sourced.ml.transformers import BOWWriter, Moder
 from sourced.ml.utils import add_engine_args
+
+
+DEFAULT_FILTER_ARG = "**/*.asdf"
 
 
 class ArgumentDefaultsHelpFormatterNoNone(argparse.ArgumentDefaultsHelpFormatter):
@@ -15,6 +23,30 @@ class ArgumentDefaultsHelpFormatterNoNone(argparse.ArgumentDefaultsHelpFormatter
         if action.default is None:
             return action.help
         return super()._get_help_string(action)
+
+
+def handle_input_arg(input_arg: str,
+                     filter_arg: Optional[str] = DEFAULT_FILTER_ARG,
+                     log: Optional[logging.Logger] = None):
+    """
+    Process input arguments and return an iterator over input files.
+
+    :param input_arg: Directory path to scan or `-` to get file paths from stdin
+    :param filter_arg: File name glob selector for input directory. Ignored if `input_arg` is \
+        equal to `-`.
+    :param log: Logger if you want to log handling process.
+    :return: an iterator over input files.
+    """
+    log = log.info if log else (lambda *x: None)
+    if input_arg == "-":
+        log("Reading file paths from stdin.")
+        for line in sys.stdin:
+            yield line.strip()
+    else:
+        log("Scanning %s", input_arg)
+        if filter_arg:
+            for path in Path(input_arg).glob(filter_arg):
+                yield str(path)
 
 
 def add_repartitioner_arg(my_parser: argparse.ArgumentParser):
@@ -38,6 +70,12 @@ def add_vocabulary_size_arg(my_parser: argparse.ArgumentParser):
     my_parser.add_argument(
         "-v", "--vocabulary-size", default=10000000, type=int,
         help="The maximum vocabulary size.")
+
+
+def add_min_docfreq(my_parser: argparse.ArgumentParser):
+    my_parser.add_argument(
+        "--min-docfreq", default=1, type=int,
+        help="The minimum document frequency of each feature.")
 
 
 def add_repo2_args(my_parser: argparse.ArgumentParser, default_packages=None):
@@ -91,3 +129,8 @@ def add_bow_args(my_parser: argparse.ArgumentParser):
     my_parser.add_argument(
         "--batch", default=BOWWriter.DEFAULT_CHUNK_SIZE, type=int,
         help="The maximum size of a single BOW file in bytes.")
+
+
+def add_filter_arg(my_parser: argparse.ArgumentParser):
+    my_parser.add_argument(
+        "--filter", default=DEFAULT_FILTER_ARG, help="File name glob selector.")

--- a/sourced/ml/cmd/args.py
+++ b/sourced/ml/cmd/args.py
@@ -1,8 +1,7 @@
 import argparse
 import json
 import logging
-from pathlib import Path
-from typing import Optional
+from typing import Optional, Union, Iterable
 import sys
 
 
@@ -25,28 +24,26 @@ class ArgumentDefaultsHelpFormatterNoNone(argparse.ArgumentDefaultsHelpFormatter
         return super()._get_help_string(action)
 
 
-def handle_input_arg(input_arg: str,
-                     filter_arg: Optional[str] = DEFAULT_FILTER_ARG,
+def handle_input_arg(input_arg: Union[str, Iterable[str]],
                      log: Optional[logging.Logger] = None):
     """
     Process input arguments and return an iterator over input files.
 
-    :param input_arg: Directory path to scan or `-` to get file paths from stdin
-    :param filter_arg: File name glob selector for input directory. Ignored if `input_arg` is \
-        equal to `-`.
+    :param input_arg: list of files to process or `-` to get \
+        file paths from stdin.
     :param log: Logger if you want to log handling process.
-    :return: an iterator over input files.
+    :return: An iterator over input files.
     """
     log = log.info if log else (lambda *x: None)
-    if input_arg == "-":
+    if input_arg == "-" or input_arg == ['-']:
         log("Reading file paths from stdin.")
         for line in sys.stdin:
             yield line.strip()
     else:
-        log("Scanning %s", input_arg)
-        if filter_arg:
-            for path in Path(input_arg).glob(filter_arg):
-                yield str(path)
+        if isinstance(input_arg, str):
+            yield input_arg
+        else:
+            yield from input_arg
 
 
 def add_repartitioner_arg(my_parser: argparse.ArgumentParser):

--- a/sourced/ml/cmd/merge_df.py
+++ b/sourced/ml/cmd/merge_df.py
@@ -1,0 +1,12 @@
+import logging
+
+from sourced.ml.models import MergeDocFreq
+from sourced.ml.cmd.args import handle_input_arg
+
+
+def merge_df_entry(args):
+    log = logging.getLogger("merge_df")
+    merger = MergeDocFreq(ordered=args.ordered,
+                          vocabulary_size=args.vocabulary_size,
+                          min_docfreq=args.min_docfreq)
+    merger.convert(handle_input_arg(args.input, args.filter, log), args.output)

--- a/sourced/ml/cmd/merge_df.py
+++ b/sourced/ml/cmd/merge_df.py
@@ -9,4 +9,4 @@ def merge_df_entry(args):
     merger = MergeDocFreq(ordered=args.ordered,
                           vocabulary_size=args.vocabulary_size,
                           min_docfreq=args.min_docfreq)
-    merger.convert(handle_input_arg(args.input, args.filter, log), args.output)
+    merger.convert(handle_input_arg(args.input, log), args.output)

--- a/sourced/ml/models/__init__.py
+++ b/sourced/ml/models/__init__.py
@@ -6,3 +6,5 @@ from sourced.ml.models.id2vec import Id2Vec
 from sourced.ml.models.tensorflow import TensorFlowModel
 from sourced.ml.models.topics import Topics
 from sourced.ml.models.quant import QuantizationLevels
+
+from sourced.ml.models.model_converters.merge_df import MergeDocFreq

--- a/sourced/ml/models/model_converters/base.py
+++ b/sourced/ml/models/model_converters/base.py
@@ -1,0 +1,126 @@
+import logging
+import multiprocessing
+import os
+from pathlib import Path
+from typing import Union, List
+
+from modelforge import Model
+from modelforge.progress_bar import progress_bar
+
+from sourced.ml.utils.pickleable_logger import PickleableLogger
+
+
+class Model2Base(PickleableLogger):
+    """
+    Base class for model -> model conversions.
+    """
+    MODEL_FROM_CLASS = None
+    MODEL_TO_CLASS = None
+
+    def __init__(self, num_processes: int=0,
+                 log_level: int=logging.DEBUG, overwrite_existing: bool=True):
+        """
+        Initializes a new instance of Model2Base class.
+
+        :param num_processes: The number of processes to execute for conversion.
+        :param log_level: Logging verbosity level.
+        :param overwrite_existing: Rewrite existing models or skip them.
+        """
+        super().__init__(log_level=log_level)
+        self.num_processes = multiprocessing.cpu_count() if num_processes == 0 else num_processes
+        self.overwrite_existing = overwrite_existing
+
+    def convert(self, models_path: List[str], destdir: str, pattern: str="**/*.asdf") -> int:
+        """
+        Performs the model -> model conversion. Runs the conversions in a pool of processes.
+
+        :param srcdir: List of Models path.
+        :param destdir: The directory where to store the models. The directory structure is \
+                        preserved.
+        :param pattern: glob pattern for the files.
+        :return: The number of converted files.
+        """
+        files = list(models_path)
+        self._log.info("Found %d files", len(files))
+        if not files:
+            return 0
+        queue_in = multiprocessing.Manager().Queue()
+        queue_out = multiprocessing.Manager().Queue(1)
+        processes = [multiprocessing.Process(target=self._process_entry,
+                                             args=(i, destdir, queue_in, queue_out))
+                     for i in range(self.num_processes)]
+        for p in processes:
+            p.start()
+        for f in files:
+            queue_in.put(f)
+        for _ in processes:
+            queue_in.put(None)
+        failures = 0
+        for _ in progress_bar(files, self._log, expected_size=len(files)):
+            filename, ok = queue_out.get()
+            if not ok:
+                failures += 1
+        for p in processes:
+            p.join()
+        self._log.info("Finished, %d failed files", failures)
+        return len(files) - failures
+
+    def convert_model(self, model: Model) -> Union[Model, None]:
+        """
+        This must be implemented in the child classes.
+
+        :param model: The model instance to convert.
+        :return: The converted model instance or None if it is not needed.
+        """
+        raise NotImplementedError
+
+    def finalize(self, index: int, destdir: str):
+        """
+        Called for each worker in the end of the processing.
+
+        :param index: Worker's index.
+        :param destdir: The directory where to store the models.
+        """
+        pass
+
+    def _process_entry(self, index, destdir, queue_in, queue_out):
+        while True:
+            filepath = queue_in.get()
+            if filepath is None:
+                break
+            try:
+                model_path = os.path.join(destdir, os.path.split(filepath)[1])
+                if os.path.exists(model_path):
+                    if self.overwrite_existing:
+                        self._log.warning(
+                            "Model %s already exists, but will be overwrite. If you want to "
+                            "skip existing models use --disable-overwrite flag", model_path)
+                    else:
+                        self._log.warning("Model %s already exists, skipping.", model_path)
+                        queue_out.put((filepath, True))
+                        continue
+                model_from = self.MODEL_FROM_CLASS(log_level=self._log.level).load(filepath)
+                model_to = self.convert_model(model_from)
+                if model_to is not None:
+                    dirs = os.path.dirname(model_path)
+                    if dirs:
+                        os.makedirs(dirs, exist_ok=True)
+                    model_to.save(model_path, deps=model_to.meta["dependencies"])
+            except:  # nopep8
+                self._log.exception("%s failed", filepath)
+                queue_out.put((filepath, False))
+            else:
+                queue_out.put((filepath, True))
+        self.finalize(index, destdir)
+
+    def _get_log_name(self):
+        return "%s2%s" % (self.MODEL_FROM_CLASS.NAME, self.MODEL_TO_CLASS.NAME)
+
+    def _get_model_path(self, path):
+        """
+        By default, we name the converted files exactly the same.
+
+        :param path: The path relative to ``srcdir``.
+        :return: The target path for the converted model.
+        """
+        return path

--- a/sourced/ml/models/model_converters/merge_df.py
+++ b/sourced/ml/models/model_converters/merge_df.py
@@ -1,0 +1,45 @@
+from collections import defaultdict
+import logging
+import os
+from typing import Union
+
+from modelforge import Model
+
+from sourced.ml.models.model_converters.base import Model2Base
+from sourced.ml.models.df import DocumentFrequencies
+from sourced.ml.models.ordered_df import OrderedDocumentFrequencies
+
+
+class MergeDocFreq(Model2Base):
+    """
+    Merges several :class:`DocumentFrequencies` models together.
+    """
+    MODEL_FROM_CLASS = DocumentFrequencies
+    MODEL_TO_CLASS = DocumentFrequencies
+
+    def __init__(self, min_docfreq, vocabulary_size, ordered=False, *args, **kwargs):
+        super().__init__(num_processes=1, *args, **kwargs)
+        self.ordered = ordered
+        self.min_docfreq = min_docfreq
+        self.vocabulary_size = vocabulary_size
+        self._df = defaultdict(int)
+        self._docs = 0
+
+    def convert_model(self, model: Model) -> Union[Model, None]:
+        for word, freq in model:
+            self._df[word] += freq
+        self._docs += model.docs
+
+    def finalize(self, index: int, destdir: str):
+        df_model = OrderedDocumentFrequencies if self.ordered else DocumentFrequencies
+        df_model(log_level=self._log.level) \
+            .construct(self._docs, self._df) \
+            .prune(self.min_docfreq) \
+            .greatest(self.vocabulary_size) \
+            .save(self._save_path(index, destdir))
+
+    @staticmethod
+    def _save_path(index: int, destdir: str):
+        if destdir.endswith(".asdf"):
+            return destdir
+        return os.path.join(destdir, "docfreq_%d.asdf" % index)

--- a/sourced/ml/tests/models/test_tensorflow.py
+++ b/sourced/ml/tests/models/test_tensorflow.py
@@ -33,5 +33,6 @@ class TensorFlowModelTests(unittest.TestCase):
         model = TensorFlowModel().load(buffer)
         self.assertEqual(gd.node, model.graphdef.node)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/sourced/ml/tests/test_args.py
+++ b/sourced/ml/tests/test_args.py
@@ -1,0 +1,35 @@
+from io import StringIO
+import os
+import sys
+import tempfile
+import unittest
+
+
+from sourced.ml.cmd.args import handle_input_arg
+
+
+class DocumentFrequenciesTests(unittest.TestCase):
+
+    def test_handle_input_arg(self):
+        files = ["file1.asdf", "file2.asdf", "file3.asdf"]
+        files_stdin = StringIO("\n".join(files))
+        _stdin = sys.stdin
+        try:
+            sys.stdin = files_stdin
+            self.assertEqual(files, list(handle_input_arg("-")))
+        finally:
+            sys.stdin = _stdin
+
+        with tempfile.TemporaryDirectory(prefix="srcdml_handle_input_arg_") as dirname:
+            for filename in files:
+                open(os.path.join(dirname, filename), 'a').close()
+            self.assertEqual(set(files),
+                             set(os.path.split(x)[1] for x in
+                                 handle_input_arg(dirname)))
+            self.assertEqual({"file1.asdf"},
+                             set(os.path.split(x)[1] for x in
+                                 handle_input_arg(dirname, filter_arg="*1*")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sourced/ml/tests/test_args.py
+++ b/sourced/ml/tests/test_args.py
@@ -1,7 +1,5 @@
 from io import StringIO
-import os
 import sys
-import tempfile
 import unittest
 
 
@@ -20,15 +18,10 @@ class DocumentFrequenciesTests(unittest.TestCase):
         finally:
             sys.stdin = _stdin
 
-        with tempfile.TemporaryDirectory(prefix="srcdml_handle_input_arg_") as dirname:
-            for filename in files:
-                open(os.path.join(dirname, filename), 'a').close()
-            self.assertEqual(set(files),
-                             set(os.path.split(x)[1] for x in
-                                 handle_input_arg(dirname)))
-            self.assertEqual({"file1.asdf"},
-                             set(os.path.split(x)[1] for x in
-                                 handle_input_arg(dirname, filter_arg="*1*")))
+        self.assertEqual(set(files),
+                         set(handle_input_arg(files)))
+        self.assertEqual({files[0]},
+                         set(handle_input_arg(files[0])))
 
 
 if __name__ == "__main__":

--- a/sourced/ml/tests/test_main.py
+++ b/sourced/ml/tests/test_main.py
@@ -26,6 +26,7 @@ class MainTests(unittest.TestCase):
             "repos2roles_ids": "repos2roles_and_ids_entry",
             "repos2id_distance": "repos2id_distance_entry",
             "repos2id_sequence": "repos2id_sequence_entry",
+            "merge-df": "merge_df_entry",
         }
         parser = main.get_parser()
         subcommands = set([x.dest for x in parser._subparsers._actions[2]._choices_actions])

--- a/sourced/ml/tests/test_merge_df.py
+++ b/sourced/ml/tests/test_merge_df.py
@@ -1,0 +1,61 @@
+import os
+import tempfile
+import unittest
+
+from sourced.ml.models import DocumentFrequencies
+from sourced.ml.models.model_converters.merge_df import MergeDocFreq
+
+
+class FakeModel:
+    def __init__(self, df):
+        self.df = df
+        self.docs = 1
+
+    def __iter__(self):
+        yield from self.df.items()
+
+
+class Model2BaseTests(unittest.TestCase):
+    def setUp(self):
+        self.model1 = FakeModel({
+                "one": 1,
+                "two": 2,
+                "three": 3,
+            })
+        self.model2 = FakeModel({
+                "four": 4,
+                "three": 3,
+                "five": 5,
+            })
+        self.merge_df = MergeDocFreq(min_docfreq=1, vocabulary_size=100)
+        self.merge_result = {"one": 1,
+                             "two": 2,
+                             "three": 6,
+                             "four": 4,
+                             "five": 5}
+
+    def test_convert_model(self):
+        self.merge_df.convert_model(self.model1)
+        self.assertEqual(self.merge_df._docs, 1)
+        self.assertEqual(self.merge_df._df, self.model1.df)
+        self.merge_df.convert_model(self.model2)
+        self.assertEqual(self.merge_df._docs, 2)
+        self.assertEqual(self.merge_df._df, self.merge_result)
+
+    def test_finalize(self):
+        self.merge_df.convert_model(self.model1)
+        self.merge_df.convert_model(self.model2)
+        with tempfile.TemporaryDirectory(prefix="merge-df-") as tmpdir:
+            dest = os.path.join(tmpdir, "df.asdf")
+            self.merge_df.finalize(None, dest)
+            df = DocumentFrequencies().load(dest)
+            self.assertEqual(df.docs, 2)
+            self.assertEqual(df._df, self.merge_result)
+
+    def test_save_path(self):
+        self.assertEqual(self.merge_df._save_path(0, "df.asdf"), "df.asdf")
+        self.assertEqual(self.merge_df._save_path(0, "df"), os.path.join("df", "docfreq_0.asdf"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sourced/ml/tests/test_model2base.py
+++ b/sourced/ml/tests/test_model2base.py
@@ -1,0 +1,100 @@
+import os
+import tempfile
+import unittest
+
+from sourced.ml.models.model_converters.base import Model2Base
+
+
+class FromModel:
+    NAME = "from"
+    meta = {"dependencies": tuple()}
+
+    def __init__(self, **kwargs):
+        pass
+
+    def load(self, source):
+        pass
+
+
+class ToModel:
+    NAME = "to"
+    output = None
+    meta = {"dependencies": tuple()}
+
+    def __init__(self, **kwargs):
+        pass
+
+    def save(self, output, deps=None):
+        ToModel.output = output
+
+
+class Model2Test(Model2Base):
+    MODEL_FROM_CLASS = FromModel
+    MODEL_TO_CLASS = ToModel
+    finalized = False
+
+    def convert_model(self, model):
+        return ToModel()
+
+
+class MockingModel2Test(Model2Base):
+    MODEL_FROM_CLASS = FromModel
+    MODEL_TO_CLASS = ToModel
+    finalized = False
+
+    def convert_model(self, model):
+        return ToModel()
+
+    def finalize(self, index: int, destdir: str):
+        self.finalized = True
+
+
+class RaisingModel2Test(Model2Base):
+    MODEL_FROM_CLASS = FromModel
+    MODEL_TO_CLASS = ToModel
+
+    def convert_model(self, model):
+        raise ValueError("happens")
+
+
+class FakeQueue:
+    def __init__(self, contents: list):
+        self.contents = contents
+
+    def get(self):
+        return self.contents.pop()
+
+    def put(self, item):
+        self.contents.append(item)
+
+
+class Model2BaseTests(unittest.TestCase):
+    def test_convert(self):
+        converter = Model2Test(num_processes=2)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status = converter.convert(os.listdir(os.path.dirname(__file__)), tmpdir,
+                                       pattern="**/*.py")
+            self.assertGreater(status, 20)
+
+    def test_process_entry(self):
+        converter = MockingModel2Test(num_processes=2)
+        queue_in = FakeQueue([None, "srcdir/job"])
+        queue_out = FakeQueue([])
+        with tempfile.TemporaryDirectory(prefix="sourced-ml-") as tmpdir:
+            converter._process_entry(
+                0, os.path.join(tmpdir, "destdir"), queue_in, queue_out)
+            self.assertTrue(os.path.exists(os.path.join(tmpdir, "destdir")))
+            self.assertEqual(ToModel.output, os.path.join(tmpdir, "destdir", "job"))
+        self.assertTrue(converter.finalized)
+        self.assertEqual(queue_out.contents, [("srcdir/job", True)])
+
+    def test_process_entry_exception(self):
+        converter = RaisingModel2Test(num_processes=2)
+        queue_in = FakeQueue([None, "srcdir/job"])
+        queue_out = FakeQueue([])
+        converter._process_entry(0, "destdir", queue_in, queue_out)
+        self.assertEqual(queue_out.contents, [("srcdir/job", False)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Since we need to merge the models, as a spark is not reliable enough I add `merge_df` subcommand.
As was discussed I take the old code for Document Frequencies model because it is small enough to be processed by one node. 

I make some minor modifications just to integrate old code to the new codebase and write more tests in `test_merge_df.py`.

The biggest files `model_converters/base.py` and `test_model2base.py` are mostly the same. 