### PR TITLE
Add coocc model merger

### DIFF
--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -222,7 +222,7 @@ def get_parser() -> argparse.ArgumentParser:
         help="Save OrderedDocumentFrequencies. "
              "If not specified DocumentFrequencies model will be saved")
     # ------------------------------------------------------------------------
-    merge_coocc = add_parser("merge-coocc", "Merge Cooccurrences models to a singe one.")
+    merge_coocc = add_parser("merge-coocc", "Merge several Cooccurrences models together.")
     merge_coocc.set_defaults(handler=merge_coocc_entry)
     add_spark_args(merge_coocc)
     add_filter_arg(merge_coocc)
@@ -239,8 +239,8 @@ def get_parser() -> argparse.ArgumentParser:
              "Identifiers that are not present in the model will be ignored.")
     merge_coocc.add_argument(
         "--no-spark", action="store_true", default=False,
-        help="Do not use spark, but python native code. Can save time and memory consumption if "
-             "data fits into one PC.")
+        help="Use the local reduction instead of PySpark. "
+             "Can be faster and consume less memory if the data fits into RAM.")
     return parser
 
 

--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -10,13 +10,13 @@ from sourced.ml.transformers import Moder
 from sourced.ml.cmd import bigartm2asdf_entry, dump_model, projector_entry, bow2vw_entry, \
     run_swivel, postprocess_id2vec, preprocess_id2vec, repos2coocc_entry, repos2df_entry, \
     repos2ids_entry, repos2bow_entry, repos2roles_and_ids_entry, repos2id_distance_entry, \
-    repos2id_sequence_entry, preprocess_repos_entry, merge_df_entry
+    repos2id_sequence_entry, preprocess_repos_entry, merge_df_entry, merge_coocc_entry
 from sourced.ml.cmd.args import add_df_args, add_feature_args, add_split_stem_arg, \
     add_vocabulary_size_arg, add_repo2_args, add_bow_args, add_repartitioner_arg, add_filter_arg, \
     add_min_docfreq, add_dzhigurda_arg, \
     ArgumentDefaultsHelpFormatterNoNone
 from sourced.ml.cmd.run_swivel import mirror_tf_args
-from sourced.ml.utils import install_bigartm
+from sourced.ml.utils import install_bigartm, add_spark_args
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -221,7 +221,26 @@ def get_parser() -> argparse.ArgumentParser:
         "--ordered", action="store_true", default=False,
         help="Save OrderedDocumentFrequencies. "
              "If not specified DocumentFrequencies model will be saved")
-
+    # ------------------------------------------------------------------------
+    merge_coocc = add_parser("merge-coocc", "Merge Cooccurrences models to a singe one.")
+    merge_coocc.set_defaults(handler=merge_coocc_entry)
+    add_spark_args(merge_coocc)
+    add_filter_arg(merge_coocc)
+    merge_coocc.add_argument(
+        "-o", "--output", required=True,
+        help="Path to the merged Cooccurrences model.")
+    merge_coocc.add_argument(
+        "-i", "--input", required=True,
+        help="Cooccurrences models input files."
+             "Use `-i -` to read input files from stdin.")
+    merge_coocc.add_argument(
+        "--docfreq", required=True,
+        help="[IN] Specify OrderedDocumentFrequencies model. "
+             "Identifiers that are not present in the model will be ignored.")
+    merge_coocc.add_argument(
+        "--no-spark", action="store_true", default=False,
+        help="Do not use spark, but python native code. Can save time and memory consumption if "
+             "data fits into one PC.")
     return parser
 
 

--- a/sourced/ml/cmd/__init__.py
+++ b/sourced/ml/cmd/__init__.py
@@ -3,6 +3,7 @@ from sourced.ml.cmd.bigartm2asdf import bigartm2asdf_entry
 from sourced.ml.cmd.bow_converters import bow2vw_entry
 from sourced.ml.cmd.dump_model import dump_model
 from sourced.ml.cmd.merge_df import merge_df_entry
+from sourced.ml.cmd.merge_coocc import merge_coocc_entry
 from sourced.ml.cmd.postprocess_id2vec import postprocess_id2vec
 from sourced.ml.cmd.preprocess_id2vec import preprocess_id2vec
 from sourced.ml.cmd.preprocess_repos import preprocess_repos_entry

--- a/sourced/ml/cmd/merge_coocc.py
+++ b/sourced/ml/cmd/merge_coocc.py
@@ -1,0 +1,75 @@
+import logging
+import operator
+from uuid import uuid4
+
+from modelforge.progress_bar import progress_bar
+import numpy as np
+from scipy.sparse import coo_matrix
+
+from sourced.ml.cmd.args import handle_input_arg
+from sourced.ml.extractors.helpers import filter_kwargs
+from sourced.ml.models import OrderedDocumentFrequencies, Cooccurrences
+from sourced.ml.transformers import CooccModelSaver
+from sourced.ml.utils.engine import pause
+from sourced.ml.utils.spark import create_spark
+
+
+MAX_INT32 = 2**31 - 1
+
+
+@pause
+def merge_coocc_entry(args):
+    log = logging.getLogger("merge_coocc")
+    log.setLevel(args.log_level)
+    filepaths = list(handle_input_arg(args.input, log))
+    log.info("Found %d files", len(filepaths))
+    df = OrderedDocumentFrequencies().load(args.docfreq)
+    if args.no_spark:
+        merge_coocc_entry_no_spark(df, filepaths, log, args)
+    else:
+        merge_coocc_entry_spark(df, filepaths, log, args)
+
+
+def merge_coocc_entry_spark(df, filepaths, log, args):
+    session_name = "merge_coocc-%s" % uuid4()
+    session = create_spark(session_name, **filter_kwargs(args.__dict__, create_spark))
+    spark_context = session.sparkContext
+    global_index = spark_context.broadcast(df.order)
+
+    coocc_rdds = []
+    for path in progress_bar(filepaths, log):
+        coocc = Cooccurrences().load(path)
+        rdd = coocc.matrix_to_rdd(spark_context)  # rdd structure: ((row, col), weight)
+        tokens = spark_context.broadcast(coocc.tokens)
+        coocc_rdds.append(
+            rdd.map(lambda row: ((global_index.value.get(tokens.value[row[0][0]], -1),
+                                  global_index.value.get(tokens.value[row[0][1]], -1)),
+                                 np.uint32(row[1])))
+               .filter(lambda row: row[0][0] >= 0))
+
+    log.info("Union of concurrence matrices...")
+    rdd = spark_context \
+        .union(coocc_rdds) \
+        .reduceByKey(lambda x, y: min(MAX_INT32, x + y))
+    CooccModelSaver(args.output, df)(rdd)
+
+
+def merge_coocc_entry_no_spark(df, filepaths, log, args):
+    log.info("Without spark")
+    shape = (len(df) + 1, len(df) + 1)
+    result = coo_matrix(shape, dtype=np.uint32)
+    for path in progress_bar(filepaths, log):
+        coocc = Cooccurrences().load(path)
+        index = [df.order.get(x, len(df) + 1) for x in coocc.tokens]
+        rows = [index[x] for x in coocc.matrix.row]
+        cols = [index[x] for x in coocc.matrix.col]
+        result += coo_matrix(
+            (coocc.matrix.data, (rows, cols)), shape=shape, dtype=np.uint32)
+        indx_overflow = np.where(result.data > MAX_INT32)
+        if indx_overflow[0].size > 0:
+            log.warning("Overflow in %d elements."
+                        "They will be saturated to %d" % (indx_overflow[0].size, MAX_INT32))
+            result.data[indx_overflow] = MAX_INT32
+    Cooccurrences() \
+        .construct(df.tokens(), result[:-1, :-1]) \
+        .save(args.output, (df,))

--- a/sourced/ml/cmd/merge_coocc.py
+++ b/sourced/ml/cmd/merge_coocc.py
@@ -1,5 +1,4 @@
 import logging
-import operator
 from uuid import uuid4
 
 from modelforge.progress_bar import progress_bar
@@ -22,12 +21,33 @@ def merge_coocc_entry(args):
     log = logging.getLogger("merge_coocc")
     log.setLevel(args.log_level)
     filepaths = list(handle_input_arg(args.input, log))
-    log.info("Found %d files", len(filepaths))
+    log.info("Will merge %d files", len(filepaths))
     df = OrderedDocumentFrequencies().load(args.docfreq)
     if args.no_spark:
         merge_coocc_entry_no_spark(df, filepaths, log, args)
     else:
         merge_coocc_entry_spark(df, filepaths, log, args)
+
+
+def load_and_check(filepaths: list, log: logging.Logger):
+    """
+    Load Cooccurrences models from filepaths list and perform simple check:
+    1. If model contains values more than MAX_INT32 we saturate.
+    2. If model contains negative values we consider it as corrupted, report and skip.
+    """
+    for path in progress_bar(filepaths, log):
+        coocc = Cooccurrences().load(path)
+        negative_values = np.where(coocc.matrix.data < 0)
+        if negative_values[0].size > 0:
+            log.warning("Model %s is corrupted and will be skipped. "
+                        "It contains negative elements.", path)
+            continue
+        too_big_values = np.where(coocc.matrix.data > MAX_INT32)
+        if too_big_values[0].size > 0:
+            log.warning("Model %s contains elements with values more than MAX_INT32. "
+                        "They will be saturated to MAX_INT32", path)
+            coocc.matrix.data[too_big_values] = MAX_INT32
+        yield path, coocc
 
 
 def merge_coocc_entry_spark(df, filepaths, log, args):
@@ -37,17 +57,28 @@ def merge_coocc_entry_spark(df, filepaths, log, args):
     global_index = spark_context.broadcast(df.order)
 
     coocc_rdds = []
-    for path in progress_bar(filepaths, log):
-        coocc = Cooccurrences().load(path)
+
+    def local_to_global(local_index):
+        """
+        Converts token index of co-occurrence matrix to the common index.
+        For example index, 5 correspond to `get` token for a current model.
+        And `get` have index 7 in the result.
+        So we convert 5 to `get` via tokens list and `get` to 7 via global_index mapping.
+        If global_index do not have `get` token, it returns -1.
+        """
+        return global_index.value.get(tokens.value[local_index], -1)
+
+    for path, coocc in load_and_check(filepaths, log):
         rdd = coocc.matrix_to_rdd(spark_context)  # rdd structure: ((row, col), weight)
+        log.info("Broadcasting tokens order for %s model...", path)
         tokens = spark_context.broadcast(coocc.tokens)
         coocc_rdds.append(
-            rdd.map(lambda row: ((global_index.value.get(tokens.value[row[0][0]], -1),
-                                  global_index.value.get(tokens.value[row[0][1]], -1)),
+            rdd.map(lambda row: ((local_to_global(row[0][0]),
+                                  local_to_global(row[0][1])),
                                  np.uint32(row[1])))
                .filter(lambda row: row[0][0] >= 0))
 
-    log.info("Union of concurrence matrices...")
+    log.info("Calculating the union of cooccurrence matrices...")
     rdd = spark_context \
         .union(coocc_rdds) \
         .reduceByKey(lambda x, y: min(MAX_INT32, x + y))
@@ -55,11 +86,31 @@ def merge_coocc_entry_spark(df, filepaths, log, args):
 
 
 def merge_coocc_entry_no_spark(df, filepaths, log, args):
-    log.info("Without spark")
-    shape = (len(df) + 1, len(df) + 1)
+    """
+    Algorithm explanation:
+
+    1. Although we store result in uint32, we actually never have elements greater than MAX_INT32
+    2. We assume that both result and the summed matrix do not have elements greater than MAX_INT32
+    3. As soon as we have a value bigger than MAX_INT32 after summing, we saturate
+    4. Thus we lose 2x data range but do not allocate any additional memory and it works faster
+       than MAX_UINT32 checks
+    5. Only ? elements saturate in PGA so this is fine
+
+    """
+    # TODO(zurk): recheck the number of saturated elements.
+    log.info("Merging cooccurrences without using PySpark")
+    shape = (len(df) + 1,) * 2
     result = coo_matrix(shape, dtype=np.uint32)
-    for path in progress_bar(filepaths, log):
-        coocc = Cooccurrences().load(path)
+    for path, coocc in load_and_check(filepaths, log):
+        negative_values = np.where(coocc.matrix.data < 0)
+        if negative_values[0].size > 0:
+            log.warning("Model %s corrupted will be skipped. It contains negative elements.")
+            continue
+        too_big_values = np.where(coocc.matrix.data > MAX_INT32)
+        if too_big_values[0].size > 0:
+            log.warning("Model %s contains elements with values more than MAX_INT32. "
+                        "They will be saturated to MAX_INT32" % path)
+            coocc.matrix.data[too_big_values] = MAX_INT32
         index = [df.order.get(x, len(df) + 1) for x in coocc.tokens]
         rows = [index[x] for x in coocc.matrix.row]
         cols = [index[x] for x in coocc.matrix.col]
@@ -67,8 +118,8 @@ def merge_coocc_entry_no_spark(df, filepaths, log, args):
             (coocc.matrix.data, (rows, cols)), shape=shape, dtype=np.uint32)
         indx_overflow = np.where(result.data > MAX_INT32)
         if indx_overflow[0].size > 0:
-            log.warning("Overflow in %d elements."
-                        "They will be saturated to %d" % (indx_overflow[0].size, MAX_INT32))
+            log.warning("Overflow in %d elements. They will be saturated to MAX_INT32",
+                        indx_overflow[0].size)
             result.data[indx_overflow] = MAX_INT32
     Cooccurrences() \
         .construct(df.tokens(), result[:-1, :-1]) \

--- a/sourced/ml/models/coocc.py
+++ b/sourced/ml/models/coocc.py
@@ -1,3 +1,4 @@
+import pyspark
 from modelforge.model import Model, split_strings, assemble_sparse_matrix, \
     merge_strings, disassemble_sparse_matrix
 from modelforge.models import register_model
@@ -48,3 +49,10 @@ Matrix: shape: %s non-zero: %d""" % (
     def _generate_tree(self):
         return {"tokens": merge_strings(self.tokens),
                 "matrix": disassemble_sparse_matrix(self.matrix)}
+
+    def matrix_to_rdd(self, spark_context: pyspark.SparkContext) -> pyspark.RDD:
+        self._log.info("Convert coocc model to RDD...")
+        rdd_row = spark_context.parallelize(self._matrix.row)
+        rdd_col = spark_context.parallelize(self._matrix.col)
+        rdd_data = spark_context.parallelize(self._matrix.data)
+        return rdd_row.zip(rdd_col).zip(rdd_data)

--- a/sourced/ml/tests/test_main.py
+++ b/sourced/ml/tests/test_main.py
@@ -28,6 +28,7 @@ class MainTests(unittest.TestCase):
             "repos2idseq": "repos2id_sequence_entry",
             "preprocrepos": "preprocess_repos_entry",
             "merge-df": "merge_df_entry",
+            "merge-coocc": "merge_coocc_entry",
         }
         parser = main.get_parser()
         subcommands = set([x.dest for x in parser._subparsers._actions[2]._choices_actions])

--- a/sourced/ml/tests/test_merge_coocc_entry.py
+++ b/sourced/ml/tests/test_merge_coocc_entry.py
@@ -1,0 +1,64 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+
+from sourced.ml.cmd import merge_coocc_entry
+from sourced.ml.models import Cooccurrences
+from sourced.ml.tests import models
+
+
+def get_args(_input_dir, _no_spark):
+    class args:
+        input = [os.path.join(_input_dir, x) for x in os.listdir(_input_dir)]
+        output = os.path.join(_input_dir, "res_coocc.asdf")
+        docfreq = models.COOCC_DF
+        pause = False
+        filter = "**/*.asdf"
+        log_level = "INFO"
+        no_spark = _no_spark
+    return args
+
+
+class MergeCooccEntry(unittest.TestCase):
+    def check_coocc(self, output):
+        coocc = Cooccurrences().load(models.COOCC)
+        res = Cooccurrences().load(output)
+        self.assertEqual(len(res.tokens), len(coocc.tokens))
+        permutation = [coocc.tokens.index(token) for token in res.tokens]
+        self.assertTrue(np.all(res.matrix.todense() ==
+                               3 * coocc.matrix.todense()[permutation][:, permutation]))
+
+    def test_with_spark(self):
+        with tempfile.TemporaryDirectory(prefix="merge-coocc-entry-test-") as input_dir:
+            coocc_filename = os.path.split(models.COOCC)[1]
+            shutil.copyfile(models.COOCC,
+                            os.path.join(input_dir, coocc_filename))
+            shutil.copyfile(models.COOCC,
+                            os.path.join(input_dir, "2.".join(coocc_filename.split("."))))
+            shutil.copyfile(models.COOCC,
+                            os.path.join(input_dir, "3.".join(coocc_filename.split("."))))
+
+            args = get_args(input_dir, False)
+            merge_coocc_entry(args)
+            self.check_coocc(args.output)
+
+    def test_without_spark(self):
+        with tempfile.TemporaryDirectory(prefix="merge-coocc-entry-test-") as input_dir:
+            coocc_filename = os.path.split(models.COOCC)[1]
+            shutil.copyfile(models.COOCC,
+                            os.path.join(input_dir, coocc_filename))
+            shutil.copyfile(models.COOCC,
+                            os.path.join(input_dir, "2.".join(coocc_filename.split("."))))
+            shutil.copyfile(models.COOCC,
+                            os.path.join(input_dir, "3.".join(coocc_filename.split("."))))
+
+            args = get_args(input_dir, True)
+            merge_coocc_entry(args)
+            self.check_coocc(args.output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sourced/ml/tests/test_merge_coocc_entry.py
+++ b/sourced/ml/tests/test_merge_coocc_entry.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import tempfile
@@ -5,9 +6,11 @@ import unittest
 
 import numpy as np
 
-from sourced.ml.cmd import merge_coocc_entry
+from sourced.ml.cmd.merge_coocc import merge_coocc_entry, load_and_check, MAX_INT32
 from sourced.ml.models import Cooccurrences
 from sourced.ml.tests import models
+
+COPIES_NUMBER = 3
 
 
 def get_args(_input_dir, _no_spark):
@@ -23,41 +26,77 @@ def get_args(_input_dir, _no_spark):
 
 
 class MergeCooccEntry(unittest.TestCase):
-    def check_coocc(self, output):
+    def check_coocc(self, output, copies_number=COPIES_NUMBER):
         coocc = Cooccurrences().load(models.COOCC)
         res = Cooccurrences().load(output)
         self.assertEqual(len(res.tokens), len(coocc.tokens))
         permutation = [coocc.tokens.index(token) for token in res.tokens]
         self.assertTrue(np.all(res.matrix.todense() ==
-                               3 * coocc.matrix.todense()[permutation][:, permutation]))
+                               copies_number *
+                               coocc.matrix.todense()[permutation][:, permutation]))
+
+    def copy_models(self, model_path, to_dir, n):
+        coocc_filename = os.path.split(model_path)[1]
+        for i in range(n):
+            shutil.copyfile(model_path,
+                            os.path.join(to_dir, "{}.".format(i).join(coocc_filename.split("."))))
 
     def test_with_spark(self):
-        with tempfile.TemporaryDirectory(prefix="merge-coocc-entry-test-") as input_dir:
-            coocc_filename = os.path.split(models.COOCC)[1]
-            shutil.copyfile(models.COOCC,
-                            os.path.join(input_dir, coocc_filename))
-            shutil.copyfile(models.COOCC,
-                            os.path.join(input_dir, "2.".join(coocc_filename.split("."))))
-            shutil.copyfile(models.COOCC,
-                            os.path.join(input_dir, "3.".join(coocc_filename.split("."))))
-
+        with tempfile.TemporaryDirectory(prefix="merge-coocc-entry-test") as input_dir:
+            self.copy_models(models.COOCC, input_dir, COPIES_NUMBER)
             args = get_args(input_dir, False)
             merge_coocc_entry(args)
             self.check_coocc(args.output)
 
     def test_without_spark(self):
-        with tempfile.TemporaryDirectory(prefix="merge-coocc-entry-test-") as input_dir:
-            coocc_filename = os.path.split(models.COOCC)[1]
-            shutil.copyfile(models.COOCC,
-                            os.path.join(input_dir, coocc_filename))
-            shutil.copyfile(models.COOCC,
-                            os.path.join(input_dir, "2.".join(coocc_filename.split("."))))
-            shutil.copyfile(models.COOCC,
-                            os.path.join(input_dir, "3.".join(coocc_filename.split("."))))
-
+        with tempfile.TemporaryDirectory(prefix="merge-coocc-entry-test") as input_dir:
+            self.copy_models(models.COOCC, input_dir, COPIES_NUMBER)
             args = get_args(input_dir, True)
             merge_coocc_entry(args)
             self.check_coocc(args.output)
+
+    def test_load_and_check(self):
+        with tempfile.TemporaryDirectory(prefix="merge-coocc-entry-test") as input_dir:
+            self.copy_models(models.COOCC, input_dir, COPIES_NUMBER)
+            args = get_args(input_dir, True)
+            c_neg = Cooccurrences().load(args.input[0])
+            c_neg.matrix.data[0] = -1
+            c_neg.save(args.input[0])
+            self.assertEqual(len(list(load_and_check(args.input, logging.getLogger("test")))), 2)
+
+            c_neg = Cooccurrences().load(args.input[0])
+            c_neg.matrix.data = np.uint32(c_neg.matrix.data)
+            c_neg.matrix.data[0] = MAX_INT32 + 1
+            c_neg.save(args.input[0])
+            for path, coocc in load_and_check(args.input, logging.getLogger("test")):
+                self.assertTrue(np.all(coocc.matrix.data <= MAX_INT32))
+                break
+
+    def test_overflow_with_spark(self):
+        with tempfile.TemporaryDirectory(prefix="merge-coocc-entry-test") as input_dir:
+            self.copy_models(models.COOCC, input_dir, COPIES_NUMBER)
+            args = get_args(input_dir, False)
+            c_neg = Cooccurrences().load(args.input[0])
+            c_neg.matrix.data[0] = MAX_INT32 - c_neg.matrix.data[0]
+            c_neg.save(args.input[0])
+            merge_coocc_entry(args)
+
+            result = Cooccurrences().load(args.output)
+            self.assertTrue(np.all(result.matrix.data <= MAX_INT32))
+            self.assertTrue(np.all(result.matrix.data >= 0))
+
+    def test_overflow_without_spark(self):
+        with tempfile.TemporaryDirectory(prefix="merge-coocc-entry-test") as input_dir:
+            self.copy_models(models.COOCC, input_dir, 10)
+            args = get_args(input_dir, True)
+            c_neg = Cooccurrences().load(args.input[0])
+            c_neg.matrix.data[0] = MAX_INT32 - 5 * c_neg.matrix.data[0]
+            c_neg.save(args.input[0])
+            merge_coocc_entry(args)
+
+            result = Cooccurrences().load(args.output)
+            self.assertTrue(np.all(result.matrix.data <= MAX_INT32))
+            self.assertTrue(np.all(result.matrix.data >= 0))
 
 
 if __name__ == '__main__':

--- a/sourced/ml/transformers/coocc.py
+++ b/sourced/ml/transformers/coocc.py
@@ -28,7 +28,8 @@ class CooccModelSaver(Transformer):
         """
         rows = sparse_matrix.collect()
 
-        mat_row, mat_col, mat_weights = zip(*rows)
+        mat_index, mat_weights = zip(*rows)
+        mat_row, mat_col = zip(*mat_index)
         tokens_num = len(self.tokens_list)
 
         self._log.info("Building matrix...")
@@ -77,10 +78,9 @@ class CooccConstructor(Transformer):
             stack.extend(children)
 
     def __call__(self, uasts):
-        sparse_matrix = uasts.flatMap(self._process_row)\
-            .reduceByKey(operator.add)\
-            .map(lambda row: (row[0][0], row[0][1], row[1]))
-        return sparse_matrix
+        return uasts \
+            .flatMap(self._process_row) \
+            .reduceByKey(operator.add)
 
     def _process_row(self, row: Row):
         for uast in row[EngineConstants.Columns.Uast]:


### PR DESCRIPTION
Depends on https://github.com/src-d/ml/pull/252, but they are not tightly coupled.

Since we need to merge the models, as a spark is not reliable enough I add `merge_coocc` subcommand.

As was discussed I use spark to process data because it can be big enough not to be processed by one node. I decided not to add another Transformer because this subcommand is quite different from our `repo2` commands.