### PR TITLE
Add handling of read errors to spark conf

### DIFF
--- a/sourced/ml/tests/test_engine.py
+++ b/sourced/ml/tests/test_engine.py
@@ -13,5 +13,6 @@ class EngineTests(unittest.TestCase):
         config = []
         packages = []
         add_engine_dependencies("latest", config, packages)
-        self.assertEqual(config, ["spark.tech.sourced.engine.cleanup.skip=false"])
+        self.assertEqual(config, ["spark.tech.sourced.engine.cleanup.skip=false",
+                                  "spark.tech.sourced.engine.skip.read.errors=true"])
         self.assertEqual(packages, ["tech.sourced:engine:latest"])

--- a/sourced/ml/utils/engine.py
+++ b/sourced/ml/utils/engine.py
@@ -34,6 +34,7 @@ def add_engine_args(my_parser, default_packages=None):
 def add_engine_dependencies(engine, config=None, packages=None):
     # to clean up unpacked Siva files, see https://github.com/src-d/engine/issues/348
     config.append("spark.tech.sourced.engine.cleanup.skip=false")
+    config.append("spark.tech.sourced.engine.skip.read.errors=true")
     packages.append("tech.sourced:engine:" + engine)
 
 


### PR DESCRIPTION
We raised [this issue](https://github.com/src-d/engine/issues/385) which was addressed in [this PR](https://github.com/src-d/engine/pull/395) which just got merged, this PR just ports the change to the Spark configuration in ml.