### PR TITLE
Add create_or_load_ordered_df function

### DIFF
--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -11,8 +11,7 @@ from sourced.ml.cmd import bigartm2asdf_entry, dump_model, projector_entry, bow2
     repos2ids_entry, repos2bow_entry, repos2roles_and_ids_entry, repos2id_distance_entry, \
     repos2id_sequence_entry
 from sourced.ml.cmd.args import add_df_args, add_feature_args, add_split_stem_arg, \
-    add_vocabulary_size_arg, add_repo2_args, add_bow_args, add_repartitioner_arg, \
-    ArgumentDefaultsHelpFormatterNoNone
+    add_repo2_args, add_bow_args, add_repartitioner_arg, ArgumentDefaultsHelpFormatterNoNone
 from sourced.ml.cmd.run_swivel import mirror_tf_args
 from sourced.ml.utils import install_bigartm
 
@@ -123,13 +122,9 @@ def get_parser() -> argparse.ArgumentParser:
     preproc_parser = add_parser(
         "id2vec_preproc", "Convert a sparse co-occurrence matrix to the Swivel shards.")
     preproc_parser.set_defaults(handler=preprocess_id2vec)
-    add_vocabulary_size_arg(preproc_parser)
+    add_df_args(preproc_parser)
     preproc_parser.add_argument("-s", "--shard-size", default=4096, type=int,
                                 help="The shard (submatrix) size.")
-    preproc_parser.add_argument(
-        "--docfreq", default=None,
-        help="[IN] Path to the pre-calculated document frequencies in asdf format "
-             "(DF in TF-IDF).")
     preproc_parser.add_argument(
         "-i", "--input",
         help="Concurrence model produced by repos2coocc.")
@@ -154,12 +149,11 @@ def get_parser() -> argparse.ArgumentParser:
     id2vec_project_parser = add_parser(
         "id2vec_project", "Present id2vec model in Tensorflow Projector.")
     id2vec_project_parser.set_defaults(handler=projector_entry)
+    add_df_args(id2vec_project_parser, required=False)
     id2vec_project_parser.add_argument("-i", "--input", required=True,
                                        help="id2vec model to present.")
     id2vec_project_parser.add_argument("-o", "--output", required=True,
                                        help="Projector output directory.")
-    id2vec_project_parser.add_argument("--docfreq", help="docfreq model to pick the most "
-                                                         "significant identifiers.")
     id2vec_project_parser.add_argument("--no-browser", action="store_true",
                                        help="Do not open the browser.")
     # ------------------------------------------------------------------------

--- a/sourced/ml/cmd/args.py
+++ b/sourced/ml/cmd/args.py
@@ -57,13 +57,15 @@ def add_repo2_args(my_parser: argparse.ArgumentParser, default_packages=None):
     add_engine_args(my_parser, default_packages)
 
 
-def add_df_args(my_parser: argparse.ArgumentParser):
+def add_df_args(my_parser: argparse.ArgumentParser, required=True):
     my_parser.add_argument(
         "--min-docfreq", default=1, type=int,
         help="The minimum document frequency of each feature.")
-    my_parser.add_argument(
-        "--docfreq", required=True,
-        help="[OUT] The path to the OrderedDocumentFrequencies model.")
+    df_group = my_parser.add_mutually_exclusive_group(required=required)
+    df_group.add_argument(
+        "--docfreq-out", help="Path to save generated DocumentFrequencies model.")
+    df_group.add_argument(
+        "--docfreq-in", help="Path to load pre-generated DocumentFrequencies model.")
     add_vocabulary_size_arg(my_parser)
 
 

--- a/sourced/ml/cmd/preprocess_id2vec.py
+++ b/sourced/ml/cmd/preprocess_id2vec.py
@@ -34,7 +34,8 @@ def preprocess_id2vec(args):
     :return: None
     """
     log = logging.getLogger("preproc")
-    df_model = DocumentFrequencies().load(source=args.docfreq)
+    log.info("Loading docfreq model from %s", args.docfreq_in)
+    df_model = DocumentFrequencies(log_level=args.log_level).load(source=args.docfreq_in)
     coocc_model = Cooccurrences().load(args.input)
     try:
         df_meta = coocc_model.get_dep(DocumentFrequencies.NAME)

--- a/sourced/ml/cmd/projector_entry.py
+++ b/sourced/ml/cmd/projector_entry.py
@@ -10,9 +10,10 @@ def projector_entry(args):
 
     log = logging.getLogger("id2vec_projector")
     id2vec = Id2Vec(log_level=args.log_level).load(source=args.input)
-    if args.docfreq:
+    if args.docfreq_in:
+        log.info("Loading docfreq model from %s", args.docfreq_in)
         from sourced.ml.models import DocumentFrequencies
-        df = DocumentFrequencies(log_level=args.log_level).load(source=args.docfreq)
+        df = DocumentFrequencies(log_level=args.log_level).load(source=args.docfreq_in)
     else:
         df = None
     if len(id2vec) < MAX_TOKENS:

--- a/sourced/ml/cmd/repos2df.py
+++ b/sourced/ml/cmd/repos2df.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from uuid import uuid4
 
@@ -31,6 +32,6 @@ def repos2df_entry(args):
         .link(Uast2BagFeatures(extractors)) \
         .link(BagFeatures2DocFreq()) \
         .execute()
-    log.info("Writing %s", args.docfreq)
-    OrderedDocumentFrequencies().construct(ndocs, df).save(args.docfreq)
+    log.info("Writing docfreq model to %s", args.docfreq_out)
+    OrderedDocumentFrequencies().construct(ndocs, df).save(args.docfreq_out)
     pipeline_graph(args, log, root)

--- a/sourced/ml/tests/test_df_util.py
+++ b/sourced/ml/tests/test_df_util.py
@@ -1,0 +1,37 @@
+import os
+import logging
+import argparse
+import tempfile
+import unittest
+
+from sourced.ml.utils.docfreq import create_or_load_ordered_df
+from sourced.ml.utils import create_spark
+from sourced.ml.transformers import ParquetLoader, UastDeserializer, UastRow2Document, Counter, \
+    Uast2BagFeatures
+from sourced.ml.extractors import IdentifiersBagExtractor
+
+import sourced.ml.tests.models as paths
+
+
+class DocumentFrequenciesUtilTests(unittest.TestCase):
+
+    def test_load(self):
+        args = argparse.Namespace(docfreq_in=paths.DOCFREQ, docfreq_out=None, min_docfreq=None,
+                                  vocabulary_size=None)
+        df_model = create_or_load_ordered_df(args, None, None)
+        self.assertEqual(df_model.docs, 1000)
+
+    def test_create(self):
+        session = create_spark("test_df_util")
+        uast_extractor = ParquetLoader(session, paths.PARQUET_DIR) \
+            .link(UastRow2Document())
+        ndocs = uast_extractor.link(Counter()).execute()
+        uast_extractor = uast_extractor.link(UastDeserializer()) \
+            .link(Uast2BagFeatures([IdentifiersBagExtractor()]))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = os.path.join(tmpdir, "df.asdf")
+            args = argparse.Namespace(docfreq_in=None, docfreq_out=tmp_path, min_docfreq=1,
+                                      vocabulary_size=1000)
+            df_model = create_or_load_ordered_df(args, ndocs, uast_extractor)
+            self.assertEqual(df_model.docs, ndocs)
+            self.assertTrue(os.path.exists(tmp_path))

--- a/sourced/ml/tests/test_id2vec.py
+++ b/sourced/ml/tests/test_id2vec.py
@@ -56,7 +56,7 @@ class Id2VecTests(unittest.TestCase):
         projector.present_embeddings = fake_present
         projector.wait = fake_wait
         args = argparse.Namespace(
-            input=paths.ID2VEC, output="fake", docfreq=paths.DOCFREQ,
+            input=paths.ID2VEC, output="fake", docfreq_in=paths.DOCFREQ,
             no_browser=False, log_level=logging.DEBUG)
         try:
             projector_entry(args)
@@ -85,7 +85,7 @@ class Id2VecTests(unittest.TestCase):
         projector.present_embeddings = fake_present
         projector.wait = fake_wait
         args = argparse.Namespace(
-            input=paths.ID2VEC, output="fake", docfreq=None,
+            input=paths.ID2VEC, output="fake", docfreq_in=None,
             no_browser=False, log_level=logging.DEBUG)
         try:
             projector_entry(args)

--- a/sourced/ml/tests/test_id_embedding.py
+++ b/sourced/ml/tests/test_id_embedding.py
@@ -71,8 +71,8 @@ def default_swivel_args(tmpdir):
 
 def default_preprocess_params(tmpdir, vocab):
     args = argparse.Namespace(
-        output=tmpdir, docfreq=COOCC_DF, input=COOCC,
-        vocabulary_size=vocab, shard_size=vocab)
+        output=tmpdir, docfreq_in=COOCC_DF, input=COOCC,
+        vocabulary_size=vocab, shard_size=vocab, log_level=0)
     return args
 
 
@@ -94,7 +94,7 @@ class IdEmbeddingTests(unittest.TestCase):
                 sorted(os.listdir(tmpdir)),
                 ["col_sums.txt", "col_vocab.txt", "row_sums.txt", "row_vocab.txt",
                  "shard-000-000.pb"])
-            df = OrderedDocumentFrequencies().load(source=args.docfreq)
+            df = OrderedDocumentFrequencies().load(source=args.docfreq_in)
             self.assertEqual(len(df), VOCAB)
             with open(os.path.join(tmpdir, "col_sums.txt")) as fin:
                 col_sums = fin.read()

--- a/sourced/ml/utils/docfreq.py
+++ b/sourced/ml/utils/docfreq.py
@@ -1,0 +1,34 @@
+import logging
+
+from sourced.ml.transformers import BagFeatures2DocFreq, Uast2BagFeatures
+from sourced.ml.models import OrderedDocumentFrequencies
+
+
+def create_or_load_ordered_df(args, ndocs: int, bag_features: Uast2BagFeatures):
+    """
+    Returns a preexisting OrderedDocumentFrequencies model from docfreq_in, or generates one
+    from the flattened bags of features using args and saves it to docfreq_out.
+
+    :param args: Instance of `argparse.Namespace` that contains docfreq_in, docfreq_out,
+                 min_docfreq, and vocabulary_size.
+    :param ndocs: Number of documents (can be repos, files or functions)
+    :param bag_features: Transformer containing bags of features extracted from the data (the call
+                         instantiates an RDD: [(key, doc), val] where key is a specific feature
+                         that appeared val times in the document doc.
+    :return: OrderedDocumentFrequencies model
+    """
+    log = logging.getLogger("create_or_load_ordered_df")
+    if args.docfreq_in:
+        log.info("Loading ordered docfreq model from %s ...", args.docfreq_in)
+        return OrderedDocumentFrequencies().load(args.docfreq_in)
+    log.info("Calculating the document frequencies, hold tight ...")
+    df = bag_features \
+        .link(BagFeatures2DocFreq()) \
+        .execute()
+    log.info("Writing ordered docfreq model to %s ...", args.docfreq_out)
+    df_model = OrderedDocumentFrequencies() \
+        .construct(ndocs, df) \
+        .prune(args.min_docfreq) \
+        .greatest(args.vocabulary_size) \
+        .save(args.docfreq_out)
+    return df_model


### PR DESCRIPTION
**CONTEXT**

While running apollo on PGA, my job failed after ~36h, out of which 20h were spent creating then writing the docfreq model. The reason for failure seems to be due to Spark instability with ml when processing very large amounts of data (shuffling of ~1TB happened multipl times ...). So I relaunched it, but instead of recalculating the ordered docfreq, I simply edited the code to not waste 20h recreating the already existing ordered docfreq model. I think that this should be integrated to the code, as in my case it halfs processing time, which is rather long - and from what I saw it can be used for both repos2cooc and repos2bow. 

**CHANGES**

- I added the file `utils/docfreq` for the `create_or_load_ordered_df` function used both in repos2cooc and repos2bow. It takes as input the `args`, logger of calling function, the transformer containing bag features and the number of docs. The function either loads an existing model, or creates and saves one from the transformer.
- I updated the `add_df` function in `cmd_entries/args`, creating an exclusive group to have either the `--docfreq-in` flag if loading or `--docfreq-out` if creating/saving. I thought it would be more explicit then checking the filepath.
- I updated the main, parsers for `preprocess_id2vec` and `projector_entry` also had `--docfreq` flag, thought it would be logical to make use of the parser, even though some args will of the namespace will not be used
- I integrated new function in  `repos2cooc` and`repos2bow`, and change the names of the args in `preprocess_id2vec`, `projector_entry` and `repos2df`
- Added a test for new function