### PR TITLE
Add swivel parameters output

### DIFF
--- a/sourced/ml/algorithms/swivel.py
+++ b/sourced/ml/algorithms/swivel.py
@@ -390,11 +390,11 @@ def main(_):
     tf.logging.set_verbosity(tf.logging.INFO)
     start_time = time.time()
 
-    omited = {"handler", "command"}
+    omitted = {"handler", "command"}
 
     log("Swivel parameters:\n" + "\n".join(
         "\t{:20} {}".format(key, value) for key, value in
-        sorted(FLAGS.__dict__.items()) if key not in omited))
+        sorted(FLAGS.__dict__.items()) if key not in omitted))
     # Create the output path.  If this fails, it really ought to fail now. :)
     if not os.path.isdir(FLAGS.output_base_path):
         os.makedirs(FLAGS.output_base_path)


### PR DESCRIPTION
Add a parameters summary that will be used during training.
It looks like:
```
INFO:tensorflow:Swivel parameters:
	    num_epochs           40.0
	    logs                 
	    per_process_gpu_memory_fraction 0.0
	    confidence_base      0.1
	    embedding_size       300
	    num_gpus             0
	    submatrix_rows       4096
	    num_concurrent_steps 2
	    confidence_scale     0.25
	    log_level            20
	    learning_rate        1.0
	    num_readers          4
	    output_base_path     /media/k/data/PGA/coocc/swivel_output_00
	    input_base_path      /media/k/data/PGA/coocc/swivel_input_00
	    trainable_bias       False
	    optimizer            Adagrad
	    submatrix_cols       4096
	    confidence_exponent  0.5
	    loss_multiplier      0.000244140625
```