### PR TITLE
Update Dockerfiles

### DIFF
--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -1,13 +1,13 @@
-FROM srcd/spark:2.2.0_v2
+FROM srcd/spark:2.2.1
 
 ADD requirements.txt package/
 
 RUN rm -rf package/sourced/ml/tests && \
     apt-get update && \
     apt-get install -y --no-install-suggests --no-install-recommends ca-certificates locales \
-      git python3 python3-dev libxml2 libxml2-dev libsnappy1 libsnappy-dev make gcc g++ curl && \
-    curl https://bootstrap.pypa.io/get-pip.py | python3 && \
+      git libxml2 libxml2-dev libsnappy1 libsnappy-dev make gcc g++ && \
     pip3 install --no-cache-dir -r package/requirements.txt && \
+    pip3 uninstall sourced-engine -y && \
     apt-get remove -y python3-dev libxml2-dev libsnappy-dev make gcc g++ curl && \
     apt-get remove -y .*-doc .*-man >/dev/null && \
     apt-get autoremove -y && \
@@ -22,9 +22,5 @@ echo "	$@"\n\
 echo\n\' > /browser && \
     chmod +x /browser
 
-ENV BROWSER /browser
-ENV LC_ALL en_US.UTF-8
-ENV PYSPARK_PYTHON python3
-ENV PYSPARK_PYTHON_DRIVER python3
-
-RUN pip3 install --no-cache-dir -r /package/requirements.txt
+ENV BROWSER=/browser \
+    LC_ALL=en_US.UTF-8 


### PR DESCRIPTION
Should not be merged before [this is](https://github.com/src-d/infrastructure/pull/78) and the new docker image `srcd/spark:2.2.1` is online. The parts taken out here have been added to `srcd/spark:2.2.1`.  We uninstall `sourced-engine` from `srcd/ml-core` because we have to uninstall it on the spark workers each time, and it's fucking annoying. 

EDIT: also we were doing `pip3 install -r requirements.txt` twice, no idea why ?

_NB: Don't forget to build and push new images when this get's merged_ 