### PR TITLE
Add option to pickle doc index and stop_pipeline of repo2bow

### DIFF
--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -53,6 +53,20 @@ def get_parser() -> argparse.ArgumentParser:
     args.add_feature_args(repos2bow_parser)
     args.add_bow_args(repos2bow_parser)
     args.add_repartitioner_arg(repos2bow_parser)
+    repos2bow_parser.add_argument(
+        "--cached-index-path", default=None,
+        help="[IN] Path to the docfreq model holding the document's index.")
+    # ------------------------------------------------------------------------
+    repos2bow_index_parser = add_parser(
+        "repos2bow_index", "Creates the index, quant and docfreq model of the bag-of-words model.")
+    repos2bow_index_parser.set_defaults(handler=cmd.repos2bow_index)
+    args.add_df_args(repos2bow_index_parser)
+    args.add_repo2_args(repos2bow_index_parser)
+    args.add_feature_args(repos2bow_index_parser)
+    args.add_repartitioner_arg(repos2bow_index_parser)
+    repos2bow_index_parser.add_argument(
+        "--cached-index-path", default=None,
+        help="[OUT] Path to the docfreq model holding the document's index.")
     # ------------------------------------------------------------------------
     repos2df_parser = add_parser(
         "repos2df", "Calculate document frequencies of features extracted from source code.")

--- a/sourced/ml/cmd/__init__.py
+++ b/sourced/ml/cmd/__init__.py
@@ -8,7 +8,8 @@ from sourced.ml.cmd.id2vec_postprocess import id2vec_postprocess
 from sourced.ml.cmd.id2vec_preprocess import id2vec_preprocess
 from sourced.ml.cmd.preprocess_repos import preprocess_repos
 from sourced.ml.cmd.id2vec_project import id2vec_project
-from sourced.ml.cmd.repos2bow import repos2bow, repos2bow_template
+from sourced.ml.cmd.repos2bow import repos2bow, repos2bow_template, repos2bow_index, \
+    repos2bow_index_template
 from sourced.ml.cmd.repos2coocc import repos2coocc
 from sourced.ml.cmd.repos2df import repos2df
 from sourced.ml.cmd.repos2ids import repos2ids

--- a/sourced/ml/cmd/args.py
+++ b/sourced/ml/cmd/args.py
@@ -108,7 +108,7 @@ def add_feature_args(my_parser: argparse.ArgumentParser, required=True):
     my_parser.add_argument("-x", "--mode", choices=Moder.Options.__all__,
                            default="file", help="What to select for analysis.")
     my_parser.add_argument(
-        "--quant", help="[OUT] The path to the QuantizationLevels model.")
+        "--quant", help="[IN/OUT] The path to the QuantizationLevels model.")
     my_parser.add_argument(
         "-f", "--feature", nargs="+",
         choices=[ex.NAME for ex in extractors.__extractors__.values()],

--- a/sourced/ml/cmd/repos2bow.py
+++ b/sourced/ml/cmd/repos2bow.py
@@ -2,12 +2,12 @@ import logging
 from uuid import uuid4
 
 from sourced.ml.extractors import create_extractors_from_args
-from sourced.ml.models import QuantizationLevels
-from sourced.ml.transformers import UastDeserializer, Uast2Quant, BagFeatures2TermFreq, \
-    Uast2BagFeatures, HeadFiles, TFIDF, Cacher, Indexer, UastRow2Document, BOWWriter, Moder, \
-    create_uast_source, Repartitioner
+from sourced.ml.transformers import UastDeserializer, BagFeatures2TermFreq, Uast2BagFeatures, \
+    HeadFiles, TFIDF, Cacher, Indexer, UastRow2Document, BOWWriter, Moder, create_uast_source, \
+    Repartitioner
 from sourced.ml.utils.engine import pipeline_graph, pause
 from sourced.ml.utils.docfreq import create_or_load_ordered_df
+from sourced.ml.utils.quant import create_or_apply_quant
 
 
 @pause
@@ -25,21 +25,18 @@ def repos2bow_template(args, select=HeadFiles, cache_hook=None, save_hook=None):
     # Row items.
     uast_extractor = uast_extractor.link(UastRow2Document())
     log.info("Extracting UASTs and indexing documents...")
-    document_indexer = Indexer(Uast2BagFeatures.Columns.document)
-    uast_extractor.link(document_indexer).execute()
+    document_indexer = Indexer(Uast2BagFeatures.Columns.document,
+                               cached_index_path=args.cached_index_path)
+    if args.index_in is None:
+        uast_extractor.link(document_indexer).execute()
     ndocs = len(document_indexer)
     log.info("Number of documents: %d", ndocs)
     uast_extractor = uast_extractor.link(UastDeserializer())
-    quant = Uast2Quant(extractors)
-    uast_extractor.link(quant).execute()
-    if quant.levels:
-        log.info("Writing quantization levels to %s", args.quant)
-        QuantizationLevels().construct(quant.levels).save(args.quant)
+    if args.quant:
+        create_or_apply_quant(args.quant, extractors, uast_extractor)
     uast_extractor = uast_extractor \
         .link(Uast2BagFeatures(extractors))
-
     df_model = create_or_load_ordered_df(args, ndocs, uast_extractor)
-
     bags_writer = uast_extractor \
         .link(BagFeatures2TermFreq()) \
         .link(TFIDF(df_model)) \
@@ -56,3 +53,30 @@ def repos2bow_template(args, select=HeadFiles, cache_hook=None, save_hook=None):
 
 def repos2bow(args):
     return repos2bow_template(args)
+
+
+def repos2bow_index_template(args, select=HeadFiles):
+    log = logging.getLogger("repos2bow_index")
+    extractors = create_extractors_from_args(args)
+    session_name = "repos2bow_index_features-%s" % uuid4()
+    root, start_point = create_uast_source(args, session_name, select=select)
+    uast_extractor = start_point.link(Moder(args.mode)) \
+        .link(Repartitioner.maybe(args.partitions, args.shuffle)) \
+        .link(UastRow2Document()) \
+        .link(Cacher.maybe(args.persist))
+    log.info("Extracting UASTs and indexing documents...")
+    document_indexer = Indexer(Uast2BagFeatures.Columns.document)
+    uast_extractor.link(document_indexer).execute()
+    document_indexer.save_index(args.cached_index_path)
+    ndocs = len(document_indexer)
+    log.info("Number of documents: %d", ndocs)
+    uast_extractor = uast_extractor.link(UastDeserializer())
+    if args.quant:
+        create_or_apply_quant(args.quant, extractors, uast_extractor)
+    if args.docfreq_out:
+        create_or_load_ordered_df(args, ndocs, uast_extractor.link(Uast2BagFeatures(extractors)))
+    pipeline_graph(args, log, root)
+
+
+def repos2bow_index(args):
+    return repos2bow_index_template(args)

--- a/sourced/ml/models/df.py
+++ b/sourced/ml/models/df.py
@@ -52,7 +52,7 @@ Number of documents: %d""" % (
             len(self._df), dict(islice(self._df.items(), 10)), self.docs)
 
     @property
-    def docs(self):
+    def docs(self) -> int:
         """
         Returns the number of documents.
         """

--- a/sourced/ml/models/quant.py
+++ b/sourced/ml/models/quant.py
@@ -47,3 +47,11 @@ class QuantizationLevels(Model):
         return """Schemes: %s""" % (
             sorted((v[0], "%d@%d" % (len(v[1]), len(next(iter(v[1].values()))) - 1))
                    for v in self.levels.items()))
+
+    def apply_quantization(self, extractors):
+        for extractor in extractors:
+            try:
+                extractor.quantize
+            except AttributeError:
+                continue
+            extractor.uast_to_bag.levels = self._levels[extractor.NAME]

--- a/sourced/ml/tests/test_df_util.py
+++ b/sourced/ml/tests/test_df_util.py
@@ -1,5 +1,4 @@
 import os
-import logging
 import argparse
 import tempfile
 import unittest

--- a/sourced/ml/tests/test_indexer.py
+++ b/sourced/ml/tests/test_indexer.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 from pyspark import Row
@@ -23,6 +24,15 @@ class IndexerTests(unittest.TestCase):
             .map(lambda x: Row(to_index=values[x.to_index], value=x.value)) \
             .collect()
         self.assertEqual(self.data, data_reverse)
+
+    def test_save_load(self):
+        indexer = Indexer("to_index")
+        res = indexer(self.data_rdd)
+        cached_index_path = "/tmp/index.asdf"
+        indexer.save_index(cached_index_path)
+        indexer = Indexer("to_index", cached_index_path=cached_index_path)
+        self.assertEqual(res.collect(), indexer(self.data_rdd).collect())
+        os.remove(cached_index_path)
 
 
 if __name__ == "__main__":

--- a/sourced/ml/tests/test_main.py
+++ b/sourced/ml/tests/test_main.py
@@ -23,6 +23,7 @@ class MainTests(unittest.TestCase):
             "repos2df": "repos2df",
             "repos2ids": "repos2ids",
             "repos2bow": "repos2bow",
+            "repos2bow_index": "repos2bow_index",
             "repos2roleids": "repos2roles_and_ids",
             "repos2id_distance": "repos2id_distance",
             "repos2idseq": "repos2id_sequence",

--- a/sourced/ml/tests/test_quant_util.py
+++ b/sourced/ml/tests/test_quant_util.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+
+from sourced.ml.transformers import ParquetLoader, UastRow2Document, UastDeserializer
+from sourced.ml.extractors import ChildrenBagExtractor
+from sourced.ml.models import QuantizationLevels
+from sourced.ml.utils.quant import create_or_apply_quant
+from sourced.ml.utils import create_spark
+
+import sourced.ml.tests.models as paths
+
+
+class MyTestCase(unittest.TestCase):
+    def test_apply(self):
+        extractor = ChildrenBagExtractor()
+        create_or_apply_quant(paths.QUANTLEVELS, [extractor])
+        self.assertIsNotNone(extractor.levels)
+        model_levels = QuantizationLevels().load(source=paths.QUANTLEVELS)._levels["children"]
+        for key in model_levels:
+            self.assertListEqual(list(model_levels[key]), list(extractor.levels[key]))
+
+    def test_create(self):
+        session = create_spark("test_quant_util")
+        extractor = ChildrenBagExtractor()
+        path = "/tmp/quant.asdf"
+        uast_extractor = ParquetLoader(session, paths.PARQUET_DIR) \
+            .link(UastRow2Document()) \
+            .link(UastDeserializer())
+        create_or_apply_quant(path, [extractor], uast_extractor)
+        self.assertIsNotNone(extractor.levels)
+        self.assertTrue(os.path.exists(path))
+        model_levels = QuantizationLevels().load(source=path)._levels["children"]
+        for key in model_levels:
+            self.assertListEqual(list(model_levels[key]), list(extractor.levels[key]))
+        os.remove(path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sourced/ml/transformers/uast2quant.py
+++ b/sourced/ml/transformers/uast2quant.py
@@ -1,8 +1,6 @@
 import operator
 from typing import Iterable
 
-from pyspark import Row
-
 from sourced.ml.extractors import BagsExtractor
 from sourced.ml.transformers.transformer import Transformer
 from sourced.ml.utils import EngineConstants

--- a/sourced/ml/utils/quant.py
+++ b/sourced/ml/utils/quant.py
@@ -1,0 +1,19 @@
+import os
+import logging
+from typing import List
+
+from sourced.ml.models import QuantizationLevels
+from sourced.ml.transformers import Uast2Quant
+from sourced.ml.extractors import BagsExtractor
+
+
+def create_or_apply_quant(model_path: str, extractors: List[BagsExtractor], extracted_uasts=None):
+    log = logging.getLogger("create_or_apply_quant")
+    if os.path.exists(model_path):
+        QuantizationLevels().load(source=model_path).apply_quantization(extractors)
+    else:
+        quant = Uast2Quant(extractors)
+        extracted_uasts.link(quant).execute()
+        if quant.levels:
+            log.info("Writing quantization levels to %s", model_path)
+            QuantizationLevels().construct(quant.levels).save(model_path)


### PR DESCRIPTION
[Linked PR in apollo](https://github.com/src-d/apollo/pull/61/)

**IDEA**

So since on huge batches this has not proven robust for now, and given the point of failure is during the calculation of TermFrequency right before TFIDF, I think we can run once on all the data to get the DocFreq model as well as a pickle of the index of all documents.
With these available, we can run on subsets of the total without loosing any  - the only thing is not to forget to rename the output bags or they will be overwritten.

**CONTEXT**

Don't know if this works although it should, running it tonight/tomorrow. Would like input if possible.

**CHANGES**

- main: added pickle_index as an optional input or output path. if supplied the pickle will be loaded/saved to the location
- transformers/index: logic of above functionality
- repos2bow: initialized the document indexer with the pickle feature, added an arg to the template to skips bags and metadata writing, focusing on the document_indexer and docfreq model.

EDIT: tomorrow will probably add stuff