### PR TITLE
[FIX] Bug in repartionner transformer

### DIFF
--- a/sourced/ml/cmd/repos2bow.py
+++ b/sourced/ml/cmd/repos2bow.py
@@ -47,7 +47,7 @@ def repos2bow_template(args, select=HeadFiles, cache_hook=None, save_hook=None):
         .link(Indexer(Uast2BagFeatures.Columns.token, df_model.order))
     if save_hook is not None:
         bags_writer = bags_writer \
-            .link(Repartitioner.maybe(args.partitions * 10, args.shuffle)) \
+            .link(Repartitioner.maybe(args.partitions, args.shuffle, multiplier=10)) \
             .link(save_hook())
     bags_writer.link(BOWWriter(document_indexer, df_model, args.bow, args.batch)) \
         .execute()

--- a/sourced/ml/tests/test_basic_transformers.py
+++ b/sourced/ml/tests/test_basic_transformers.py
@@ -28,6 +28,9 @@ class BasicTransformerTest(unittest.TestCase):
         repartitioned_data = Repartitioner(partitions, shuffle=True)(data)
         self.assertEqual(partitions, repartitioned_data.getNumPartitions())
 
+        repartitioned_data = Repartitioner.maybe(partitions, shuffle=True, multiplier=2)(data)
+        self.assertEqual(partitions * 2, repartitioned_data.getNumPartitions())
+
     def test_parquet_loader(self):
         # load parquet and check number of rows
         loader = ParquetLoader(session=self.spark, paths=PARQUET_DIR)

--- a/sourced/ml/transformers/basic.py
+++ b/sourced/ml/transformers/basic.py
@@ -21,9 +21,9 @@ class Repartitioner(Transformer):
         return head.coalesce(self.partitions, self.shuffle)
 
     @staticmethod
-    def maybe(partitions: Union[int, None], shuffle: bool=False):
+    def maybe(partitions: Union[int, None], shuffle: bool=False, multiplier: int=1):
         if partitions is not None:
-            return Repartitioner(partitions, shuffle)
+            return Repartitioner(partitions * multiplier, shuffle)
         else:
             return Identity()
 


### PR DESCRIPTION
**CONTEXT**

One of the reasons we added the repartionner was to allow the user to choose more freely the number of partitions. In `repos2bow_template`, given the instability of cassandra, we multiply that value by 10 before writing the bags. Problem is by default the value is None, so if not specified this creates a situation where we do:  
```
        bags_writer = bags_writer \
            .link(Repartitioner.maybe(None * 10, args.shuffle)) \
            .link(save_hook())
```

**CHANGES**

Since in the `maybe` method we check for `args.partitions` to be None like in the Cacher, we can simply add a `multiplier` parameter to this method that defaults to 1. I added a test for this, and modified `repos2bow_template` in consequence.