### PR TITLE
Change pep8 to flake8 and fix linter errors

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=99

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ stages:
   - name: deploy
     # require any tag name to deploy
     if: tag =~ .*
+addons:
+  apt:
+    packages:
+      - libsnappy-dev
 _install: &_install
   - gimme 1.8
   - source ~/.gimme/envs/latest.env
@@ -35,8 +39,8 @@ matrix:
       env: *_coverage
       install: *_install
     - python: 3.6
-      env: SCRIPT="pep8 --max-line-length=99 ."
-      install: pip install pep8
+      env: SCRIPT="flake8 --max-line-length=99 ."
+      install: pip install flake8
     - python: 3.6
       env: *_coverage
       install: *_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       env: *_coverage
       install: *_install
     - python: 3.6
-      env: SCRIPT="flake8 --max-line-length=99 ."
+      env: SCRIPT="flake8 ."
       install: pip install flake8
     - python: 3.6
       env: *_coverage

--- a/sourced/ml/algorithms/__init__.py
+++ b/sourced/ml/algorithms/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from sourced.ml.algorithms.tf_idf import log_tf_log_idf
 from sourced.ml.algorithms.token_parser import TokenParser, NoopTokenParser
 from sourced.ml.algorithms.uast_ids_to_bag import UastIds2Bag, uast2sequence

--- a/sourced/ml/algorithms/id_splitter/features.py
+++ b/sourced/ml/algorithms/id_splitter/features.py
@@ -1,7 +1,6 @@
 import logging
 import string
 import tarfile
-import warnings
 
 import numpy
 from keras.preprocessing.sequence import pad_sequences

--- a/sourced/ml/algorithms/uast_id_distance.py
+++ b/sourced/ml/algorithms/uast_id_distance.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from typing import Iterable, Tuple, Union
 from itertools import combinations
 

--- a/sourced/ml/cmd/__init__.py
+++ b/sourced/ml/cmd/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from sourced.ml.cmd.args import ArgumentDefaultsHelpFormatterNoNone
 from sourced.ml.cmd.bigartm2asdf import bigartm2asdf
 from sourced.ml.cmd.bow_converters import bow2vw

--- a/sourced/ml/cmd/repos2df.py
+++ b/sourced/ml/cmd/repos2df.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from uuid import uuid4
 

--- a/sourced/ml/cmd/repos2id_distance.py
+++ b/sourced/ml/cmd/repos2id_distance.py
@@ -2,7 +2,7 @@ import logging
 from uuid import uuid4
 
 from sourced.ml.extractors import IdentifierDistance
-from sourced.ml.transformers import UastDeserializer, Uast2BagFeatures, Cacher, UastRow2Document, \
+from sourced.ml.transformers import UastDeserializer, Uast2BagFeatures, UastRow2Document, \
     CsvSaver, create_uast_source
 from sourced.ml.transformers.basic import Rower
 from sourced.ml.utils.engine import pipeline_graph, pause

--- a/sourced/ml/extractors/__init__.py
+++ b/sourced/ml/extractors/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from sourced.ml.extractors.helpers import __extractors__, get_names_from_kwargs, \
     register_extractor, filter_kwargs, create_extractors_from_args
 from sourced.ml.extractors.bags_extractor import BagsExtractor

--- a/sourced/ml/extractors/id_sequence.py
+++ b/sourced/ml/extractors/id_sequence.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Tuple
+from typing import Iterable
 
 import bblfsh
 

--- a/sourced/ml/models/__init__.py
+++ b/sourced/ml/models/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from sourced.ml.models.bow import BOW
 from sourced.ml.models.coocc import Cooccurrences
 from sourced.ml.models.df import DocumentFrequencies

--- a/sourced/ml/models/model_converters/base.py
+++ b/sourced/ml/models/model_converters/base.py
@@ -1,7 +1,6 @@
 import logging
 import multiprocessing
 import os
-from pathlib import Path
 from typing import Union, List
 
 from modelforge import Model
@@ -106,7 +105,7 @@ class Model2Base(PickleableLogger):
                     if dirs:
                         os.makedirs(dirs, exist_ok=True)
                     model_to.save(model_path, deps=model_to.meta["dependencies"])
-            except:  # nopep8
+            except:  # noqa
                 self._log.exception("%s failed", filepath)
                 queue_out.put((filepath, False))
             else:

--- a/sourced/ml/models/model_converters/merge_df.py
+++ b/sourced/ml/models/model_converters/merge_df.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-import logging
 import os
 from typing import Union
 

--- a/sourced/ml/tests/models/test_tensorflow.py
+++ b/sourced/ml/tests/models/test_tensorflow.py
@@ -6,7 +6,7 @@ from sourced.ml.models.tensorflow import TensorFlowModel
 
 def has_tensorflow():
     try:
-        import tensorflow
+        import tensorflow  # noqa
         return True
     except ImportError:
         return False

--- a/sourced/ml/tests/test_coocc.py
+++ b/sourced/ml/tests/test_coocc.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 
 import sourced.ml.tests.models as paths

--- a/sourced/ml/tests/test_df_util.py
+++ b/sourced/ml/tests/test_df_util.py
@@ -1,5 +1,4 @@
 import os
-import logging
 import argparse
 import tempfile
 import unittest

--- a/sourced/ml/tests/test_dump.py
+++ b/sourced/ml/tests/test_dump.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import os
 import sys
 import unittest
 from contextlib import contextmanager
@@ -56,7 +55,7 @@ Number of words: 982
  'version': [1, 0, 15]}
 Shape: (5, 20)
 First 10 documents: ['repo1', 'repo2', 'repo3', 'repo4', 'repo5']
-First 10 tokens: ['i.', 'i.*', 'i.Activity', 'i.AdapterView', 'i.ArrayAdapter', 'i.Arrays', 'i.Bundle', 'i.EditText', 'i.Exception', 'i.False']\n"""  # nopep8
+First 10 tokens: ['i.', 'i.*', 'i.Activity', 'i.AdapterView', 'i.ArrayAdapter', 'i.Arrays', 'i.Bundle', 'i.EditText', 'i.Exception', 'i.False']\n"""  # noqa
 
     COOCC_DUMP = """{'created_at': datetime.datetime(2018, 1, 24, 16, 0, 2, 591553),
  'dependencies': [{'created_at': datetime.datetime(2018, 1, 24, 15, 59, 24, 129470),

--- a/sourced/ml/tests/test_id2vec.py
+++ b/sourced/ml/tests/test_id2vec.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import os
 import unittest
 
 import numpy

--- a/sourced/ml/tests/test_id_splitter_features.py
+++ b/sourced/ml/tests/test_id_splitter_features.py
@@ -124,7 +124,7 @@ class IdSplitterTest(unittest.TestCase):
             with tarfile.open(None, "w", fileobj=tmp, encoding="utf-8") as tmp_tar:
                 write_fake_identifiers(tmp_tar, n_lines=10, char_sizes=char_sizes, n_cols=2)
 
-            with self.assertRaises(IndexError) as cm:
+            with self.assertRaises(IndexError):
                 read_identifiers(csv_path=tmp.name, max_identifier_len=10, identifiers_col=3,
                                  split_identifiers_col=4)
 

--- a/sourced/ml/tests/test_projector.py
+++ b/sourced/ml/tests/test_projector.py
@@ -59,7 +59,7 @@ class ProjectorTests(unittest.TestCase):
             attempts, result = self.wait_for_web_server()
             self.assertTrue(attempts < self.MAX_ATTEMPTS or result == 0)
             self.assertTrue(web_server.running)
-        except:  # nopep8
+        except:  # noqa
             web_server.stop()
             raise
         os.environ["PROJECTOR_SERVER_TIME"] = "0"

--- a/sourced/ml/tests/test_topics.py
+++ b/sourced/ml/tests/test_topics.py
@@ -17,7 +17,7 @@ class TopicsTests(unittest.TestCase):
         self.assertEqual(res, """320 topics, 1000 tokens
 First 10 tokens: ['ulcancel', 'domainlin', 'trudi', 'fncreateinstancedbaselin', 'wbnz', 'lmultiplicand', 'otronumero', 'qxln', 'gvgq', 'polaroidish']
 Topics: unlabeled
-non-zero elements: 6211  (0.019409)""")  # nopep8
+non-zero elements: 6211  (0.019409)""")  # noqa
 
     def test_props(self):
         self.assertEqual(len(self.model), 320)

--- a/sourced/ml/transformers/__init__.py
+++ b/sourced/ml/transformers/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from sourced.ml.transformers.basic import Sampler, Collector, First, Identity, Cacher, Ignition, \
     HeadFiles, UastExtractor, FieldsSelector, ParquetSaver, ParquetLoader, Repartitioner,\
     UastDeserializer, Counter, create_uast_source, CsvSaver, LanguageSelector, DzhigurdaFiles

--- a/sourced/ml/transformers/basic.py
+++ b/sourced/ml/transformers/basic.py
@@ -253,7 +253,7 @@ class UastDeserializer(Transformer):
         for i, uast in enumerate(row[EngineConstants.Columns.Uast]):
             try:
                 row_dict[EngineConstants.Columns.Uast].append(self.parse_uast(uast))
-            except:  # nopep8
+            except:  # noqa
                 self._log.error("\nBabelfish Error: Failed to parse uast for document %s for uast "
                                 "#%s" % (row[Uast2BagFeatures.Columns.document], i))
         yield Row(**row_dict)

--- a/sourced/ml/transformers/tfidf.py
+++ b/sourced/ml/transformers/tfidf.py
@@ -1,4 +1,4 @@
-from pyspark import Row, RDD
+from pyspark import Row
 
 from sourced.ml.algorithms import log_tf_log_idf
 from sourced.ml.models import DocumentFrequencies

--- a/sourced/ml/transformers/uast2quant.py
+++ b/sourced/ml/transformers/uast2quant.py
@@ -1,8 +1,6 @@
 import operator
 from typing import Iterable
 
-from pyspark import Row
-
 from sourced.ml.extractors import BagsExtractor
 from sourced.ml.transformers.transformer import Transformer
 from sourced.ml.utils import EngineConstants

--- a/sourced/ml/utils/__init__.py
+++ b/sourced/ml/utils/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from sourced.ml.utils.bigartm import install_bigartm
 from sourced.ml.utils.bblfsh_roles import IDENTIFIER, QUALIFIED, LITERAL, FUNCTION, DECLARATION, \
     NAME

--- a/sourced/ml/utils/spark.py
+++ b/sourced/ml/utils/spark.py
@@ -6,8 +6,8 @@ import zipfile
 
 os.environ["PYSPARK_PYTHON"] = sys.executable
 
-import pyspark  # nopep8
-from pyspark.sql import SparkSession  # nopep8
+import pyspark  # noqa
+from pyspark.sql import SparkSession  # noqa
 
 
 class SparkDefault:


### PR DESCRIPTION
Implementation of #280 
`# flake8: noqa` at the top of the `__init__.py` files to get rid of the warnings about unused imports