### PR TITLE
Add language processing from parquet files

### DIFF
--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -40,7 +40,7 @@ def get_parser() -> argparse.ArgumentParser:
     preprocessing_parser.add_argument(
         "-o", "--output", required=True,
         help="[OUT] Path to the parquet files with bag batches.")
-    default_fields = ("blob_id", "repository_id", "content", "path", "commit_hash", "uast")
+    default_fields = ("blob_id", "repository_id", "content", "path", "commit_hash", "uast", "lang")
     preprocessing_parser.add_argument(
         "-f", "--fields", nargs="+", default=default_fields,
         help="Fields to save.")

--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -36,7 +36,6 @@ def get_parser() -> argparse.ArgumentParser:
     preprocessing_parser.add_argument("-x", "--mode", choices=Moder.Options.__all__,
                                       default="file", help="What to extract from repositories.")
     args.add_repo2_args(preprocessing_parser)
-    args.add_dzhigurda_arg(preprocessing_parser)
     preprocessing_parser.add_argument(
         "-o", "--output", required=True,
         help="[OUT] Path to the parquet files with bag batches.")

--- a/sourced/ml/cmd/args.py
+++ b/sourced/ml/cmd/args.py
@@ -84,8 +84,13 @@ def add_repo2_args(my_parser: argparse.ArgumentParser, default_packages=None):
     # https://github.com/bblfsh/client-scala/issues/98 resolved
     languages = ["Java", "Python", "Go", "JavaScript", "TypeScript", "Ruby", "Bash", "Php"]
     my_parser.add_argument(
-        "-l", "--languages", nargs="+", choices=languages, default=languages,
+        "-l", "--languages", nargs="+", choices=languages,
+        default=None,  # Default value for --languages arg should be None.
+                       # Otherwise if you process parquet files without 'lang' column, you will
+                       # fail to process it with any --languages argument.
         help="The programming languages to analyse.")
+    my_parser.add_argument("--blacklist", action="store_true",
+                           help="Exclude languages from `--languages` list from analysis.")
     add_engine_args(my_parser, default_packages)
 
 

--- a/sourced/ml/cmd/args.py
+++ b/sourced/ml/cmd/args.py
@@ -90,7 +90,9 @@ def add_repo2_args(my_parser: argparse.ArgumentParser, default_packages=None):
                        # fail to process it with any --languages argument.
         help="The programming languages to analyse.")
     my_parser.add_argument("--blacklist", action="store_true",
-                           help="Exclude languages from `--languages` list from analysis.")
+                           help="Exclude the languages in --languages from the analysis "
+                                "instead of filtering by default.")
+    add_dzhigurda_arg(my_parser)
     add_engine_args(my_parser, default_packages)
 
 

--- a/sourced/ml/cmd/preprocess_repos.py
+++ b/sourced/ml/cmd/preprocess_repos.py
@@ -2,8 +2,7 @@ import os
 import logging
 from uuid import uuid4
 
-from sourced.ml.transformers import FieldsSelector, Moder, DzhigurdaFiles, ParquetSaver, \
-    create_uast_source
+from sourced.ml.transformers import FieldsSelector, Moder, ParquetSaver, create_uast_source
 from sourced.ml.utils.engine import pipeline_graph, pause
 
 
@@ -17,8 +16,7 @@ def preprocess_repos(args):
         return 1
     if not args.config:
         args.config = []
-    root, start_point = create_uast_source(args, session_name,
-                                           select=lambda: DzhigurdaFiles(args.dzhigurda))
+    root, start_point = create_uast_source(args, session_name)
 
     start_point \
         .link(Moder(args.mode)) \

--- a/sourced/ml/cmd/repos2bow.py
+++ b/sourced/ml/cmd/repos2bow.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from sourced.ml.extractors import create_extractors_from_args
 from sourced.ml.transformers import UastDeserializer, BagFeatures2TermFreq, Uast2BagFeatures, \
-    HeadFiles, TFIDF, Cacher, Indexer, UastRow2Document, BOWWriter, Moder, create_uast_source, \
+    TFIDF, Cacher, Indexer, UastRow2Document, BOWWriter, Moder, create_uast_source, \
     Repartitioner, PartitionSelector, Transformer, Distinct, Collector, FieldsSelector
 from sourced.ml.utils import EngineConstants
 from sourced.ml.utils.engine import pipeline_graph, pause
@@ -13,13 +13,13 @@ from sourced.ml.models import DocumentFrequencies
 
 
 @pause
-def repos2bow_template(args, select: Transformer=HeadFiles, cache_hook: Transformer=None,
+def repos2bow_template(args, cache_hook: Transformer=None,
                        save_hook: Transformer=None):
 
     log = logging.getLogger("repos2bow")
     extractors = create_extractors_from_args(args)
     session_name = "repos2bow-%s" % uuid4()
-    root, start_point = create_uast_source(args, session_name, select=select)
+    root, start_point = create_uast_source(args, session_name)
     log.info("Loading the document index from %s ...", args.cached_index_path)
     docfreq = DocumentFrequencies().load(source=args.cached_index_path)
     document_index = {key: int(val) for (key, val) in docfreq}
@@ -106,11 +106,11 @@ def repos2bow(args):
     return repos2bow_template(args)
 
 
-def repos2bow_index_template(args, select=HeadFiles):
+def repos2bow_index_template(args):
     log = logging.getLogger("repos2bow_index")
     extractors = create_extractors_from_args(args)
     session_name = "repos2bow_index_features-%s" % uuid4()
-    root, start_point = create_uast_source(args, session_name, select=select)
+    root, start_point = create_uast_source(args, session_name)
     uast_extractor = start_point.link(Moder(args.mode)) \
         .link(Repartitioner.maybe(args.partitions, args.shuffle)) \
         .link(UastRow2Document()) \

--- a/sourced/ml/cmd/repos2ids.py
+++ b/sourced/ml/cmd/repos2ids.py
@@ -1,7 +1,7 @@
 import logging
 from uuid import uuid4
 
-from sourced.ml.transformers import ContentToIdentifiers, create_uast_source, \
+from sourced.ml.transformers import ContentToIdentifiers, create_file_source, \
     IdentifiersToDataset, CsvSaver, Repartitioner
 from sourced.ml.utils.engine import pipeline_graph, pause
 
@@ -11,7 +11,7 @@ def repos2ids(args):
     log = logging.getLogger("repos2ids")
     session_name = "repos2ids-%s" % uuid4()
 
-    root, start_point = create_uast_source(args, session_name, extract_uast=False)
+    root, start_point = create_file_source(args, session_name)
     start_point \
         .link(Repartitioner(args.partitions, args.shuffle)) \
         .link(ContentToIdentifiers(args.split)) \

--- a/sourced/ml/cmd/repos2ids.py
+++ b/sourced/ml/cmd/repos2ids.py
@@ -1,7 +1,7 @@
 import logging
 from uuid import uuid4
 
-from sourced.ml.transformers import ContentToIdentifiers, create_uast_source, LanguageSelector, \
+from sourced.ml.transformers import ContentToIdentifiers, create_uast_source, \
     IdentifiersToDataset, CsvSaver, Repartitioner
 from sourced.ml.utils.engine import pipeline_graph, pause
 
@@ -10,9 +10,8 @@ from sourced.ml.utils.engine import pipeline_graph, pause
 def repos2ids(args):
     log = logging.getLogger("repos2ids")
     session_name = "repos2ids-%s" % uuid4()
-    language_selector = LanguageSelector(languages=["null"], blacklist=True)
-    root, start_point = create_uast_source(args, session_name, language_selector=language_selector,
-                                           extract_uast=False)
+
+    root, start_point = create_uast_source(args, session_name, extract_uast=False)
     start_point \
         .link(Repartitioner(args.partitions, args.shuffle)) \
         .link(ContentToIdentifiers(args.split)) \

--- a/sourced/ml/tests/test_language_selector.py
+++ b/sourced/ml/tests/test_language_selector.py
@@ -2,7 +2,8 @@ import unittest
 from pyspark.sql.functions import lit
 
 from sourced.ml.tests.models import PARQUET_DIR, SIVA_DIR
-from sourced.ml.transformers import LanguageSelector, Collector, Ignition, HeadFiles
+from sourced.ml.transformers import LanguageSelector, Collector, Ignition, HeadFiles, \
+    LanguageExtractor
 from sourced.ml.transformers.basic import create_parquet_loader, create_engine
 
 
@@ -14,6 +15,7 @@ class LoaderTest(unittest.TestCase):
         engine = create_engine("test", SIVA_DIR)
         res = Ignition(engine) \
             .link(HeadFiles()) \
+            .link(LanguageExtractor()) \
             .link(LanguageSelector(languages1)) \
             .link(Collector()) \
             .execute()
@@ -21,6 +23,7 @@ class LoaderTest(unittest.TestCase):
 
         res = Ignition(engine) \
             .link(HeadFiles()) \
+            .link(LanguageExtractor()) \
             .link(LanguageSelector(languages2)) \
             .link(Collector()) \
             .execute()
@@ -28,6 +31,7 @@ class LoaderTest(unittest.TestCase):
 
         res = Ignition(engine) \
             .link(HeadFiles()) \
+            .link(LanguageExtractor()) \
             .link(LanguageSelector(languages2, blacklist=True)) \
             .link(Collector()) \
             .execute()
@@ -35,6 +39,7 @@ class LoaderTest(unittest.TestCase):
 
         res = Ignition(engine) \
             .link(HeadFiles()) \
+            .link(LanguageExtractor()) \
             .link(LanguageSelector([])) \
             .link(Collector()) \
             .execute()

--- a/sourced/ml/tests/test_language_selector.py
+++ b/sourced/ml/tests/test_language_selector.py
@@ -1,0 +1,56 @@
+import unittest
+from pyspark.sql.functions import lit
+
+from sourced.ml.tests.models import PARQUET_DIR, SIVA_DIR
+from sourced.ml.transformers import LanguageSelector, Collector, Ignition, HeadFiles
+from sourced.ml.transformers.basic import create_parquet_loader, create_engine
+
+
+class LoaderTest(unittest.TestCase):
+    def test_parquet(self):
+        languages1 = ["Python", "Java"]
+        languages2 = ["Java"]
+
+        engine = create_engine("test", SIVA_DIR)
+        res = Ignition(engine) \
+            .link(HeadFiles()) \
+            .link(LanguageSelector(languages1)) \
+            .link(Collector()) \
+            .execute()
+        self.assertEqual(set([x.lang for x in res]), set(languages1))
+
+        res = Ignition(engine) \
+            .link(HeadFiles()) \
+            .link(LanguageSelector(languages2)) \
+            .link(Collector()) \
+            .execute()
+        self.assertEqual(set([x.lang for x in res]), set(languages2))
+
+        res = Ignition(engine) \
+            .link(HeadFiles()) \
+            .link(LanguageSelector(languages2, blacklist=True)) \
+            .link(Collector()) \
+            .execute()
+        self.assertEqual(set(), set([x.lang for x in res]) & set(languages2))
+
+        res = Ignition(engine) \
+            .link(HeadFiles()) \
+            .link(LanguageSelector([])) \
+            .link(Collector()) \
+            .execute()
+        self.assertEqual(set(), set([x.lang for x in res]))
+
+        parquet_loader = create_parquet_loader("test_parquet", repositories=PARQUET_DIR)
+        df = parquet_loader.execute()
+        with self.assertRaises(AttributeError):
+            LanguageSelector(languages1)(df)
+
+        df_with_lang = df.withColumn("lang", lit("BestLang"))
+        self.assertEqual(0, len(LanguageSelector(languages1)(df_with_lang).collect()))
+
+        self.assertEqual(df_with_lang.collect(),
+                         LanguageSelector(["BestLang"])(df_with_lang).collect())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sourced/ml/tests/test_loader.py
+++ b/sourced/ml/tests/test_loader.py
@@ -7,7 +7,7 @@ from sourced.ml.transformers import create_uast_source
 
 class LoaderTest(unittest.TestCase):
     def test_parquet(self):
-        args = argparse.Namespace(parquet=True, repositories=PARQUET_DIR)
+        args = argparse.Namespace(parquet=True, repositories=PARQUET_DIR, languages=None)
         root, start_point = create_uast_source(args, "test_parquet")
         self.assertEqual(root, start_point)
         df = start_point.execute()
@@ -18,3 +18,7 @@ class LoaderTest(unittest.TestCase):
         self.assertEqual(row.repository_id, "github.com/sloria/flask-ghpages-example")
         self.assertEqual(row.path, "freeze.py")
         self.assertEqual(row.commit_hash, "e08278f331b2450441f7879c57ad574d9caf2032")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sourced/ml/tests/test_loader.py
+++ b/sourced/ml/tests/test_loader.py
@@ -7,9 +7,11 @@ from sourced.ml.transformers import create_uast_source
 
 class LoaderTest(unittest.TestCase):
     def test_parquet(self):
-        args = argparse.Namespace(parquet=True, repositories=PARQUET_DIR, languages=None)
+        args = argparse.Namespace(parquet=True,
+                                  repositories=PARQUET_DIR,
+                                  languages=None,
+                                  blacklist=False)
         root, start_point = create_uast_source(args, "test_parquet")
-        self.assertEqual(root, start_point)
         df = start_point.execute()
         self.assertEqual(df.count(), 6)
         row = df.rdd.first()

--- a/sourced/ml/tests/test_uast_to_id_distance.py
+++ b/sourced/ml/tests/test_uast_to_id_distance.py
@@ -11,55 +11,41 @@ class Uast2IdTreeDistanceTest(unittest.TestCase):
         self.uast2role_id_pairs = Uast2IdTreeDistance(token_parser=NoopTokenParser(),
                                                       max_distance=4)
         self.uast = BblfshClient("0.0.0.0:9432").parse(SOURCE_PY).uast
+        self.maxDiff = None
 
     def test_result(self):
         correct = [(('__spec__', 'ModuleSpec'), 2),
-                   (('__spec__', 'ModuleSpec'), 2),
                    (('__spec__', 'ModuleSpec'), 3),
-                   (('__spec__', '__package__'), 2),
+                   (('__spec__', 'ModuleSpec'), 3),
                    (('collections', 'ModuleSpec'), 2),
                    (('collections', 'ModuleSpec'), 2),
                    (('collections', 'ModuleSpec'), 3),
-                   (('collections', '__spec__'), 2),
-                   (('modules', 'modelforge.logs'), 3),
-                   (('namedtuple', 'ModuleSpec'), 2),
-                   (('namedtuple', 'ModuleSpec'), 2),
+                   (('collections', '__spec__'), 3),
                    (('namedtuple', 'ModuleSpec'), 3),
                    (('namedtuple', 'ModuleSpec'), 3),
                    (('namedtuple', 'ModuleSpec'), 3),
-                   (('namedtuple', '__spec__'), 2),
-                   (('namedtuple', '__spec__'), 3),
-                   (('namedtuple', 'collections'), 2),
+                   (('namedtuple', 'ModuleSpec'), 3),
+                   (('namedtuple', 'collections'), 3),
                    (('namedtuple', 'collections'), 3),
                    (('setup', 'modelforge.logs'), 3),
-                   (('setup_logging', 'modelforge.logs'), 2),
-                   (('setup_logging', 'modules'), 3),
-                   (('setup_logging', 'setup'), 3),
-                   (('sys', 'modelforge.logs'), 2),
-                   (('sys', 'modules'), 3),
-                   (('sys', 'modules'), 3),
-                   (('sys', 'setup'), 3),
-                   (('sys', 'setup_logging'), 2),
+                   (('setup_logging', 'modelforge.logs'), 3),
+                   (('sys', 'modelforge.logs'), 3),
+                   (('sys', 'modules'), 2),
                    (('utmain', 'ModuleSpec'), 2),
                    (('utmain', 'ModuleSpec'), 3),
                    (('utmain', 'ModuleSpec'), 3),
-                   (('utmain', '__package__'), 3),
-                   (('utmain', '__package__'), 3),
-                   (('utmain', '__spec__'), 3),
-                   (('utmain', '__spec__'), 3),
-                   (('utmain', '__spec__'), 3),
+                   (('utmain', '__package__'), 2),
+                   (('utmain', '__spec__'), 2),
+                   (('utmain', '__spec__'), 2),
                    (('utmain', 'collections'), 3),
                    (('utmain', 'modelforge.logs'), 2),
                    (('utmain', 'modelforge.logs'), 2),
-                   (('utmain', 'modules'), 3),
-                   (('utmain', 'modules'), 3),
-                   (('utmain', 'namedtuple'), 3),
                    (('utmain', 'setup'), 3),
                    (('utmain', 'setup'), 3),
-                   (('utmain', 'setup_logging'), 2),
-                   (('utmain', 'setup_logging'), 2),
-                   (('utmain', 'sys'), 2),
-                   (('utmain', 'sys'), 2)]
+                   (('utmain', 'setup_logging'), 3),
+                   (('utmain', 'setup_logging'), 3),
+                   (('utmain', 'sys'), 3),
+                   (('utmain', 'sys'), 3)]
 
         res = sorted(self.uast2role_id_pairs(self.uast))
         self.assertEqual(res, correct)
@@ -70,6 +56,7 @@ class Uast2IdLineDistanceTest(unittest.TestCase):
         self.uast2role_id_pairs = Uast2IdLineDistance(token_parser=NoopTokenParser(),
                                                       max_distance=3)
         self.uast = BblfshClient("0.0.0.0:9432").parse(SOURCE_PY).uast
+        self.maxDiff = None
 
     def test_result(self):
         correct = [(('__package__', 'ModuleSpec'), 2),

--- a/sourced/ml/tests/test_uast_to_id_sequence.py
+++ b/sourced/ml/tests/test_uast_to_id_sequence.py
@@ -12,9 +12,9 @@ class Uast2IdSequenceTest(unittest.TestCase):
         self.uast = BblfshClient("0.0.0.0:9432").parse(SOURCE_PY).uast
 
     def test_result(self):
-        correct = ['sys', 'setup_logging', 'modelforge.logs', 'utmain', 'sys', 'modules',
-                   'utmain', '__package__', 'utmain', '__spec__', 'namedtuple', 'collections',
-                   'ModuleSpec', 'namedtuple', 'utmain', '__spec__', 'ModuleSpec', 'ModuleSpec',
+        correct = ['sys', 'setup_logging', 'modelforge.logs', 'utmain', 'modules', 'sys',
+                   '__package__', 'utmain',  '__spec__', 'utmain',  'namedtuple', 'collections',
+                   'ModuleSpec', 'namedtuple', '__spec__', 'utmain', 'ModuleSpec', 'ModuleSpec',
                    'utmain', 'setup', 'setup_logging']
         res = self.uast2id_sequence(self.uast)
         self.assertEqual(res, self.uast2id_sequence.concat(correct))

--- a/sourced/ml/tests/test_uast_to_role_id_pairs.py
+++ b/sourced/ml/tests/test_uast_to_role_id_pairs.py
@@ -15,9 +15,9 @@ class Uast2NodesBagTest(unittest.TestCase):
         correct = [('ModuleSpec', 'BODY | IF | THEN'),
                    ('ModuleSpec', 'IDENTIFIER | EXPRESSION | CALL | CALLEE'),
                    ('ModuleSpec', 'STATEMENT | INCOMPLETE'),
-                   ('__package__', 'BOOLEAN | EXPRESSION | IF | CONDITION | INCOMPLETE'),
+                   ('__package__', 'BINARY | EXPRESSION | CONDITION'),
+                   ('__spec__', 'BINARY | EXPRESSION | CONDITION'),
                    ('__spec__', 'BODY | IF | THEN'),
-                   ('__spec__', 'BOOLEAN | EXPRESSION | IF | CONDITION | INCOMPLETE'),
                    ('collections', 'IDENTIFIER | IMPORT | PATHNAME'),
                    ('modelforge.logs', 'IDENTIFIER | IMPORT | PATHNAME'),
                    ('modules', 'RIGHT | EXPRESSION | INCOMPLETE'),
@@ -28,9 +28,9 @@ class Uast2NodesBagTest(unittest.TestCase):
                    ('setup_logging', 'IDENTIFIER | IMPORT | PATHNAME'),
                    ('sys', 'IDENTIFIER | IMPORT | PATHNAME'),
                    ('sys', 'RIGHT | EXPRESSION | INCOMPLETE'),
+                   ('utmain', 'BINARY | EXPRESSION | CONDITION'),
+                   ('utmain', 'BINARY | EXPRESSION | CONDITION'),
                    ('utmain', 'BODY | IF | THEN'),
-                   ('utmain', 'BOOLEAN | EXPRESSION | IF | CONDITION | INCOMPLETE'),
-                   ('utmain', 'BOOLEAN | EXPRESSION | IF | CONDITION | INCOMPLETE'),
                    ('utmain', 'FILE | MODULE'),
                    ('utmain', 'STATEMENT | INCOMPLETE')]
         res = sorted(self.uast2role_id_pairs(self.uast))

--- a/sourced/ml/transformers/__init__.py
+++ b/sourced/ml/transformers/__init__.py
@@ -2,7 +2,7 @@
 from sourced.ml.transformers.basic import Sampler, Collector, First, Identity, Cacher, Ignition, \
     HeadFiles, UastExtractor, FieldsSelector, ParquetSaver, ParquetLoader, Repartitioner, \
     UastDeserializer, Counter, create_file_source, create_uast_source, CsvSaver, LanguageSelector,\
-    DzhigurdaFiles, PartitionSelector, Distinct
+    DzhigurdaFiles, PartitionSelector, Distinct, LanguageExtractor
 from sourced.ml.transformers.indexer import Indexer
 from sourced.ml.transformers.tfidf import TFIDF
 from sourced.ml.transformers.transformer import Transformer, Execute

--- a/sourced/ml/transformers/__init__.py
+++ b/sourced/ml/transformers/__init__.py
@@ -1,8 +1,8 @@
 # flake8: noqa
 from sourced.ml.transformers.basic import Sampler, Collector, First, Identity, Cacher, Ignition, \
-    HeadFiles, UastExtractor, FieldsSelector, ParquetSaver, ParquetLoader, Repartitioner,\
-    UastDeserializer, Counter, create_uast_source, CsvSaver, LanguageSelector, DzhigurdaFiles, \
-    PartitionSelector, Distinct
+    HeadFiles, UastExtractor, FieldsSelector, ParquetSaver, ParquetLoader, Repartitioner, \
+    UastDeserializer, Counter, create_file_source, create_uast_source, CsvSaver, LanguageSelector,\
+    DzhigurdaFiles, PartitionSelector, Distinct
 from sourced.ml.transformers.indexer import Indexer
 from sourced.ml.transformers.tfidf import TFIDF
 from sourced.ml.transformers.transformer import Transformer, Execute


### PR DESCRIPTION
For some of the commands (`repos2roleids`, `repos2id_distance`) we need to know the language for the file. And as usual, it is a good idea to start them after preprocessing step. So I add several things:

1. add `lang` field to a default set to save in preprocessing step.
2. add `LanguageSelector` step if you start from parquet files in `create_uast_source` function. 
3. Adopt `LanguageSelector` itself to work from parquet files.