### PR TITLE
Make repos2bow work on PGA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       env: *_coverage
       install: *_install
     - python: 3.6
-      env: SCRIPT="flake8 ."
+      env: SCRIPT="flake8 . && (! grep -R /tmp sourced/ml/tests)"
       install: pip install flake8
     - python: 3.6
       env: *_coverage

--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -53,9 +53,7 @@ def get_parser() -> argparse.ArgumentParser:
     args.add_feature_args(repos2bow_parser)
     args.add_bow_args(repos2bow_parser)
     args.add_repartitioner_arg(repos2bow_parser)
-    repos2bow_parser.add_argument(
-        "--cached-index-path", default=None,
-        help="[IN] Path to the docfreq model holding the document's index.")
+    args.add_cached_index_arg(repos2bow_parser)
     # ------------------------------------------------------------------------
     repos2bow_index_parser = add_parser(
         "repos2bow_index", "Creates the index, quant and docfreq model of the bag-of-words model.")
@@ -64,9 +62,7 @@ def get_parser() -> argparse.ArgumentParser:
     args.add_repo2_args(repos2bow_index_parser)
     args.add_feature_args(repos2bow_index_parser)
     args.add_repartitioner_arg(repos2bow_index_parser)
-    repos2bow_index_parser.add_argument(
-        "--cached-index-path", default=None,
-        help="[OUT] Path to the docfreq model holding the document's index.")
+    args.add_cached_index_arg(repos2bow_index_parser, create=True)
     # ------------------------------------------------------------------------
     repos2df_parser = add_parser(
         "repos2df", "Calculate document frequencies of features extracted from source code.")

--- a/sourced/ml/cmd/args.py
+++ b/sourced/ml/cmd/args.py
@@ -128,18 +128,15 @@ def add_bow_args(my_parser: argparse.ArgumentParser):
         help="The maximum size of a single BOW file in bytes.")
     my_parser.add_argument(
         "--num-iterations", default=1, type=int,
-        help="The number of iterations required to parse the data.")
+        help="After partitioning by document we run the pipeline on each partition separately "
+             "in a loop. This number indicates the number of partitions.")
 
 
 def add_cached_index_arg(my_parser: argparse.ArgumentParser, create: bool = False):
-    if create:
-        my_parser.add_argument(
-            "--cached-index-path", default=None, required=True,
-            help="[OUT] Path to the docfreq model holding the document's index.")
-    else:
-        my_parser.add_argument(
-            "--cached-index-path", default=None, required=True,
-            help="[IN] Path to the docfreq model holding the document's index.")
+    direction = "OUT" if create else "IN"
+    my_parser.add_argument(
+        "--cached-index-path", default=None, required=True,
+        help="[%s] Path to the docfreq model holding the document's index." % direction)
 
 
 def add_dzhigurda_arg(my_parser):

--- a/sourced/ml/cmd/args.py
+++ b/sourced/ml/cmd/args.py
@@ -126,6 +126,20 @@ def add_bow_args(my_parser: argparse.ArgumentParser):
     my_parser.add_argument(
         "--batch", default=BOWWriter.DEFAULT_CHUNK_SIZE, type=int,
         help="The maximum size of a single BOW file in bytes.")
+    my_parser.add_argument(
+        "--num-iterations", default=1, type=int,
+        help="The number of iterations required to parse the data.")
+
+
+def add_cached_index_arg(my_parser: argparse.ArgumentParser, create: bool = False):
+    if create:
+        my_parser.add_argument(
+            "--cached-index-path", default=None, required=True,
+            help="[OUT] Path to the docfreq model holding the document's index.")
+    else:
+        my_parser.add_argument(
+            "--cached-index-path", default=None, required=True,
+            help="[IN] Path to the docfreq model holding the document's index.")
 
 
 def add_dzhigurda_arg(my_parser):

--- a/sourced/ml/cmd/repos2bow.py
+++ b/sourced/ml/cmd/repos2bow.py
@@ -4,50 +4,103 @@ from uuid import uuid4
 from sourced.ml.extractors import create_extractors_from_args
 from sourced.ml.transformers import UastDeserializer, BagFeatures2TermFreq, Uast2BagFeatures, \
     HeadFiles, TFIDF, Cacher, Indexer, UastRow2Document, BOWWriter, Moder, create_uast_source, \
-    Repartitioner
+    Repartitioner, Partitioner, PartitionSelector, Transformer, Distinct, Collector, FieldsSelector
+from sourced.ml.utils import EngineConstants
 from sourced.ml.utils.engine import pipeline_graph, pause
 from sourced.ml.utils.docfreq import create_or_load_ordered_df
 from sourced.ml.utils.quant import create_or_apply_quant
+from sourced.ml.models import DocumentFrequencies
 
 
 @pause
-def repos2bow_template(args, select=HeadFiles, cache_hook=None, save_hook=None):
+def repos2bow_template(args, select: Transformer=HeadFiles, cache_hook: Transformer=None,
+                       save_hook: Transformer=None):
+
     log = logging.getLogger("repos2bow")
     extractors = create_extractors_from_args(args)
     session_name = "repos2bow-%s" % uuid4()
     root, start_point = create_uast_source(args, session_name, select=select)
-    uast_extractor = start_point.link(Moder(args.mode)) \
-        .link(Repartitioner.maybe(args.partitions, args.shuffle)) \
-        .link(Cacher.maybe(args.persist))
-    if cache_hook is not None:
-        uast_extractor.link(cache_hook()).execute()
-    # We link UastRow2Document after Cacher here because cache_hook() may want to have all possible
-    # Row items.
-    uast_extractor = uast_extractor.link(UastRow2Document())
-    log.info("Extracting UASTs and indexing documents...")
-    document_indexer = Indexer(Uast2BagFeatures.Columns.document,
-                               cached_index_path=args.cached_index_path)
-    if args.cached_index_path is None:
-        uast_extractor.link(document_indexer).execute()
-    ndocs = len(document_indexer)
-    log.info("Number of documents: %d", ndocs)
-    uast_extractor = uast_extractor.link(UastDeserializer())
-    if args.quant:
-        create_or_apply_quant(args.quant, extractors, uast_extractor)
-    uast_extractor = uast_extractor \
-        .link(Uast2BagFeatures(extractors))
-    df_model = create_or_load_ordered_df(args, ndocs, uast_extractor)
-    bags_writer = uast_extractor \
-        .link(BagFeatures2TermFreq()) \
-        .link(TFIDF(df_model)) \
-        .link(document_indexer) \
-        .link(Indexer(Uast2BagFeatures.Columns.token, df_model.order))
-    if save_hook is not None:
-        bags_writer = bags_writer \
-            .link(Repartitioner.maybe(args.partitions, args.shuffle, multiplier=10)) \
-            .link(save_hook())
-    bags_writer.link(BOWWriter(document_indexer, df_model, args.bow, args.batch)) \
-        .execute()
+    log.info("Loading the document index from %s ...", args.cached_index_path)
+    document_index = DocumentFrequencies().load(source=args.cached_index_path).df
+    document_index = {key: int(document_index[key]) for key in document_index}
+
+    try:
+        if args.quant is not None:
+            create_or_apply_quant(args.quant, extractors, None)
+        df_model = create_or_load_ordered_df(args, None, None)
+    except ValueError:
+        return 1
+    ec = EngineConstants.Columns
+
+    if args.mode == Moder.Options.repo:
+        def custom_mapping(r):
+            return r[ec.RepositoryId]
+    else:
+        def custom_mapping(r):
+            return r[ec.RepositoryId] + UastRow2Document.REPO_PATH_SEP + \
+                r[ec.Path] + UastRow2Document.PATH_BLOB_SEP + r[ec.BlobId]
+
+    log.info("Caching UASTs to disk after partitioning by document ...")
+    start_point = start_point.link(Moder(args.mode)) \
+        .link(Partitioner.maybe(args.num_iterations, custom_mapping)) \
+        .link(Cacher.maybe("DISK_ONLY"))
+    for num_part in range(args.num_iterations):
+        log.info("Running job %s of %s", num_part + 1, args.num_iterations)
+        selected_part = start_point \
+            .link(PartitionSelector(num_part))  \
+            .link(Repartitioner.maybe(args.partitions, args.shuffle)) \
+            .link(Cacher.maybe(args.persist))
+        if cache_hook is not None:
+            selected_part.link(cache_hook()).execute()
+        uast_extractor = selected_part \
+            .link(UastRow2Document()) \
+            .link(Cacher.maybe(args.persist))
+        log.info("Collecting distinct documents ...")
+        documents = uast_extractor \
+            .link(FieldsSelector([Uast2BagFeatures.Columns.document])) \
+            .link(Distinct()) \
+            .link(Collector()) \
+            .execute()
+        selected_part.unpersist()
+        documents = set(row.document for row in documents)
+        reduced_doc_index = {
+            key: document_index[key] for key in document_index if key in documents}
+        document_indexer = Indexer(Uast2BagFeatures.Columns.document, root.session.sparkContext,
+                                   reduced_doc_index)
+        log.info("Processing %s distinct documents", len(documents))
+        bags = uast_extractor \
+            .link(UastDeserializer()) \
+            .link(Uast2BagFeatures(extractors)) \
+            .link(BagFeatures2TermFreq()) \
+            .link(Cacher.maybe(args.persist))
+        log.info("Extracting UASTs and collecting distinct tokens ...")
+        tokens = bags \
+            .link(FieldsSelector([Uast2BagFeatures.Columns.token])) \
+            .link(Distinct()) \
+            .link(Collector()) \
+            .execute()
+        uast_extractor.unpersist()
+        tokens = set(row.token for row in tokens)
+        reduced_token_freq = {key: df_model[key] for key in df_model.df if key in tokens}
+        reduced_token_index = {key: df_model.order[key] for key in df_model.df if key in tokens}
+        log.info("Processing %s distinct tokens", len(reduced_token_freq))
+        log.info("Indexing by document and token ...")
+        bags_writer = bags \
+            .link(TFIDF(reduced_token_freq, df_model.docs, root.session.sparkContext)) \
+            .link(document_indexer) \
+            .link(Indexer(Uast2BagFeatures.Columns.token, root.session.sparkContext,
+                          reduced_token_index))
+        if save_hook is not None:
+            bags_writer = bags_writer \
+                .link(Repartitioner.maybe(args.partitions, args.shuffle, multiplier=10)) \
+                .link(save_hook())
+        bow = args.bow.split(".asdf")[0] + "_" + str(num_part + 1) + ".asdf"
+        bags_writer \
+            .link(Partitioner.maybe(
+                args.partitions, lambda x: x[Uast2BagFeatures.Columns.document])) \
+            .link(BOWWriter(document_indexer, df_model, bow, args.batch)) \
+            .execute()
+        bags.unpersist()
     pipeline_graph(args, log, root)
 
 
@@ -64,8 +117,8 @@ def repos2bow_index_template(args, select=HeadFiles):
         .link(Repartitioner.maybe(args.partitions, args.shuffle)) \
         .link(UastRow2Document()) \
         .link(Cacher.maybe(args.persist))
-    log.info("Extracting UASTs and indexing documents...")
-    document_indexer = Indexer(Uast2BagFeatures.Columns.document)
+    log.info("Extracting UASTs and indexing documents ...")
+    document_indexer = Indexer(Uast2BagFeatures.Columns.document, root.session.sparkContext)
     uast_extractor.link(document_indexer).execute()
     document_indexer.save_index(args.cached_index_path)
     ndocs = len(document_indexer)

--- a/sourced/ml/models/df.py
+++ b/sourced/ml/models/df.py
@@ -32,6 +32,12 @@ class DocumentFrequencies(Model):
         self._df = df
         return self
 
+    """
+    WE DO NOT ADD THIS
+
+    def df(self) -> dict:
+    """
+
     def _load_tree(self, tree: dict, tokens=None):
         if tokens is None:
             tokens = split_strings(tree["tokens"])
@@ -58,13 +64,11 @@ Number of documents: %d""" % (
         """
         return self._docs
 
-    @property
+    """
+    WE DO NOT ADD THIS
+    
     def df(self) -> dict:
-        """
-        Returns the document frequency dict.
-        To use with care, as this exposes the dictionary !!!
-        """
-        return self._df
+    """
 
     def prune(self, threshold: int) -> "DocumentFrequencies":
         """
@@ -156,3 +160,9 @@ Number of documents: %d""" % (
         Returns the list of tokens.
         """
         return list(self._df)
+
+    """
+    WE DO NOT ADD THIS
+
+    def df(self) -> dict:
+    """

--- a/sourced/ml/models/df.py
+++ b/sourced/ml/models/df.py
@@ -66,7 +66,7 @@ Number of documents: %d""" % (
 
     """
     WE DO NOT ADD THIS
-    
+
     def df(self) -> dict:
     """
 

--- a/sourced/ml/models/df.py
+++ b/sourced/ml/models/df.py
@@ -58,6 +58,14 @@ Number of documents: %d""" % (
         """
         return self._docs
 
+    @property
+    def df(self) -> dict:
+        """
+        Returns the document frequency dict.
+        To use with care, as this exposes the dictionary !!!
+        """
+        return self._df
+
     def prune(self, threshold: int) -> "DocumentFrequencies":
         """
         Removes tokens which occur less than `threshold` times.

--- a/sourced/ml/tests/test_df_util.py
+++ b/sourced/ml/tests/test_df_util.py
@@ -34,3 +34,15 @@ class DocumentFrequenciesUtilTests(unittest.TestCase):
             df_model = create_or_load_ordered_df(args, ndocs, uast_extractor)
             self.assertEqual(df_model.docs, ndocs)
             self.assertTrue(os.path.exists(tmp_path))
+
+    def test_error(self):
+        with self.assertRaises(ValueError):
+            create_or_load_ordered_df(argparse.Namespace(docfreq_in=None), 10, None)
+
+        with self.assertRaises(ValueError):
+            session = create_spark("test_df_util")
+            uast_extractor = ParquetLoader(session, paths.PARQUET_DIR) \
+                .link(UastRow2Document()) \
+                .link(UastDeserializer()) \
+                .link(Uast2BagFeatures([IdentifiersBagExtractor()]))
+            create_or_load_ordered_df(argparse.Namespace(docfreq_in=None), None, uast_extractor)

--- a/sourced/ml/tests/test_dump.py
+++ b/sourced/ml/tests/test_dump.py
@@ -14,6 +14,7 @@ import sourced.ml.tests.models as paths
 
 cache_dir = os.path.join(tempfile.gettempdir(), "ml-test-dump")
 
+
 @contextmanager
 def captured_output():
     log = StringIO()

--- a/sourced/ml/tests/test_dump.py
+++ b/sourced/ml/tests/test_dump.py
@@ -3,6 +3,7 @@ import logging
 import sys
 import os
 import shutil
+import tempfile
 import unittest
 from contextlib import contextmanager
 from io import StringIO
@@ -10,6 +11,8 @@ from io import StringIO
 from modelforge.registry import dump_model
 import sourced.ml.tests.models as paths
 
+
+cache_dir = os.path.join(tempfile.gettempdir(), "ml-test-dump")
 
 @contextmanager
 def captured_output():
@@ -73,8 +76,8 @@ Matrix: shape: (304, 304) non-zero: 16001
 """
 
     def tearDown(self):
-        if os.path.exists("/tmp/ml-test-dump"):
-            shutil.rmtree("/tmp/ml-test-dump")
+        if os.path.exists(cache_dir):
+            shutil.rmtree(cache_dir)
 
     def test_id2vec(self):
         with captured_output() as (out, _, _):
@@ -102,7 +105,7 @@ Matrix: shape: (304, 304) non-zero: 16001
     def _get_args(input):
         return argparse.Namespace(input=input, backend=None, args=None, username="",
                                   password="", index_repo="https://github.com/src-d/models",
-                                  cache="/tmp/ml-test-dump", signoff=False, log_level="WARNING")
+                                  cache=cache_dir, signoff=False, log_level="WARNING")
 
 
 if __name__ == "__main__":

--- a/sourced/ml/tests/test_indexer.py
+++ b/sourced/ml/tests/test_indexer.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import unittest
 

--- a/sourced/ml/tests/test_indexer.py
+++ b/sourced/ml/tests/test_indexer.py
@@ -3,6 +3,7 @@ import unittest
 
 from pyspark import Row
 
+from sourced.ml.models import DocumentFrequencies
 from sourced.ml.tests import create_spark_for_test
 from sourced.ml.transformers import Indexer
 
@@ -11,13 +12,13 @@ class IndexerTests(unittest.TestCase):
     def setUp(self):
         data = [Row(to_index="to_index%d" % i, value=i) for i in range(10)]
         self.data = data
-        self.sc = create_spark_for_test()
-        self.data_rdd = self.sc.sparkContext \
+        self.session = create_spark_for_test()
+        self.data_rdd = self.session.sparkContext \
             .parallelize(range(len(data))) \
             .map(lambda x: data[x])
 
     def test_call(self):
-        indexer = Indexer("to_index")
+        indexer = Indexer("to_index", self.session.sparkContext)
         res = indexer(self.data_rdd)
         values = indexer.values()
         data_reverse = res \
@@ -26,11 +27,14 @@ class IndexerTests(unittest.TestCase):
         self.assertEqual(self.data, data_reverse)
 
     def test_save_load(self):
-        indexer = Indexer("to_index")
+        indexer = Indexer("to_index", self.session.sparkContext)
         res = indexer(self.data_rdd)
         cached_index_path = "/tmp/index.asdf"
         indexer.save_index(cached_index_path)
-        indexer = Indexer("to_index", cached_index_path=cached_index_path)
+        document_index = DocumentFrequencies().load(source=cached_index_path).df
+        document_index = {key: int(document_index[key]) for key in document_index}
+        indexer = Indexer("to_index", column2id=document_index,
+                          sc=self.session.sparkContext)
         self.assertEqual(res.collect(), indexer(self.data_rdd).collect())
         os.remove(cached_index_path)
 

--- a/sourced/ml/tests/test_quant_util.py
+++ b/sourced/ml/tests/test_quant_util.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 
 from sourced.ml.transformers import ParquetLoader, UastRow2Document, UastDeserializer
@@ -22,17 +23,17 @@ class MyTestCase(unittest.TestCase):
     def test_create(self):
         session = create_spark("test_quant_util")
         extractor = ChildrenBagExtractor()
-        path = "/tmp/quant.asdf"
-        uast_extractor = ParquetLoader(session, paths.PARQUET_DIR) \
-            .link(UastRow2Document()) \
-            .link(UastDeserializer())
-        create_or_apply_quant(path, [extractor], uast_extractor)
-        self.assertIsNotNone(extractor.levels)
-        self.assertTrue(os.path.exists(path))
-        model_levels = QuantizationLevels().load(source=path)._levels["children"]
-        for key in model_levels:
-            self.assertListEqual(list(model_levels[key]), list(extractor.levels[key]))
-        os.remove(path)
+        with tempfile.NamedTemporaryFile(suffix="-quant.asdf") as tmp:
+            path = tmp.name
+            uast_extractor = ParquetLoader(session, paths.PARQUET_DIR) \
+                .link(UastRow2Document()) \
+                .link(UastDeserializer())
+            create_or_apply_quant(path, [extractor], uast_extractor)
+            self.assertIsNotNone(extractor.levels)
+            self.assertTrue(os.path.exists(path))
+            model_levels = QuantizationLevels().load(source=path)._levels["children"]
+            for key in model_levels:
+                self.assertListEqual(list(model_levels[key]), list(extractor.levels[key]))
 
     def test_error(self):
         with self.assertRaises(ValueError):

--- a/sourced/ml/tests/test_quant_util.py
+++ b/sourced/ml/tests/test_quant_util.py
@@ -34,6 +34,10 @@ class MyTestCase(unittest.TestCase):
             self.assertListEqual(list(model_levels[key]), list(extractor.levels[key]))
         os.remove(path)
 
+    def test_error(self):
+        with self.assertRaises(ValueError):
+            create_or_apply_quant("", [], None)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/sourced/ml/tests/test_quant_util.py
+++ b/sourced/ml/tests/test_quant_util.py
@@ -23,7 +23,7 @@ class MyTestCase(unittest.TestCase):
     def test_create(self):
         session = create_spark("test_quant_util")
         extractor = ChildrenBagExtractor()
-        with tempfile.NamedTemporaryFile(suffix="-quant.asdf") as tmp:
+        with tempfile.NamedTemporaryFile(mode="r+b", suffix="-quant.asdf") as tmp:
             path = tmp.name
             uast_extractor = ParquetLoader(session, paths.PARQUET_DIR) \
                 .link(UastRow2Document()) \

--- a/sourced/ml/tests/test_tfidf.py
+++ b/sourced/ml/tests/test_tfidf.py
@@ -10,10 +10,11 @@ from sourced.ml.transformers import TFIDF
 
 class TFIDFTests(unittest.TestCase):
     def setUp(self):
-        self.sc = create_spark_for_test()
+        self.session = create_spark_for_test()
 
         df = DocumentFrequencies().construct(10, {str(i): i for i in range(1, 5)})
-        self.tfidf = TFIDF(df=df)
+        self.docs = df.docs
+        self.tfidf = TFIDF(df.df, df.docs, self.session.sparkContext)
 
         class Columns:
             """
@@ -28,12 +29,12 @@ class TFIDFTests(unittest.TestCase):
     def test_call(self):
         baseline = {
             Row(d=dict(i)["d"], t=dict(i)["t"],
-                v=log_tf_log_idf(dict(i)["v"], int(dict(i)["t"]), self.tfidf.df.docs))
+                v=log_tf_log_idf(dict(i)["v"], int(dict(i)["t"]), self.docs))
             for i in tfidf_data.term_freq_result
         }
 
         result = self.tfidf(
-            self.sc.sparkContext
+            self.session.sparkContext
                 .parallelize(tfidf_data.term_freq_result)
                 .map(lambda x: Row(**dict(x)))).collect()
         self.assertEqual(set(result), baseline)

--- a/sourced/ml/tests/test_tfidf.py
+++ b/sourced/ml/tests/test_tfidf.py
@@ -14,7 +14,7 @@ class TFIDFTests(unittest.TestCase):
 
         df = DocumentFrequencies().construct(10, {str(i): i for i in range(1, 5)})
         self.docs = df.docs
-        self.tfidf = TFIDF(df.df, df.docs, self.session.sparkContext)
+        self.tfidf = TFIDF(df, df.docs, self.session.sparkContext)
 
         class Columns:
             """

--- a/sourced/ml/transformers/__init__.py
+++ b/sourced/ml/transformers/__init__.py
@@ -1,7 +1,8 @@
 # flake8: noqa
 from sourced.ml.transformers.basic import Sampler, Collector, First, Identity, Cacher, Ignition, \
     HeadFiles, UastExtractor, FieldsSelector, ParquetSaver, ParquetLoader, Repartitioner,\
-    UastDeserializer, Counter, create_uast_source, CsvSaver, LanguageSelector, DzhigurdaFiles
+    UastDeserializer, Counter, create_uast_source, CsvSaver, LanguageSelector, DzhigurdaFiles, \
+    PartitionBy, PartitionSelector
 from sourced.ml.transformers.indexer import Indexer
 from sourced.ml.transformers.tfidf import TFIDF
 from sourced.ml.transformers.transformer import Transformer, Execute

--- a/sourced/ml/transformers/__init__.py
+++ b/sourced/ml/transformers/__init__.py
@@ -2,7 +2,7 @@
 from sourced.ml.transformers.basic import Sampler, Collector, First, Identity, Cacher, Ignition, \
     HeadFiles, UastExtractor, FieldsSelector, ParquetSaver, ParquetLoader, Repartitioner,\
     UastDeserializer, Counter, create_uast_source, CsvSaver, LanguageSelector, DzhigurdaFiles, \
-    Partitioner, PartitionSelector, Distinct
+    PartitionSelector, Distinct
 from sourced.ml.transformers.indexer import Indexer
 from sourced.ml.transformers.tfidf import TFIDF
 from sourced.ml.transformers.transformer import Transformer, Execute

--- a/sourced/ml/transformers/__init__.py
+++ b/sourced/ml/transformers/__init__.py
@@ -2,7 +2,7 @@
 from sourced.ml.transformers.basic import Sampler, Collector, First, Identity, Cacher, Ignition, \
     HeadFiles, UastExtractor, FieldsSelector, ParquetSaver, ParquetLoader, Repartitioner,\
     UastDeserializer, Counter, create_uast_source, CsvSaver, LanguageSelector, DzhigurdaFiles, \
-    PartitionBy, PartitionSelector
+    Partitioner, PartitionSelector, Distinct
 from sourced.ml.transformers.indexer import Indexer
 from sourced.ml.transformers.tfidf import TFIDF
 from sourced.ml.transformers.transformer import Transformer, Execute

--- a/sourced/ml/transformers/bow_writer.py
+++ b/sourced/ml/transformers/bow_writer.py
@@ -45,9 +45,8 @@ class BOWWriter(Transformer):
         nparts = int(numpy.ceil(
             len(self.document_indexer) * (avglen * (4 + 4) + avgdocnamelen) / self.chunk_size))
         self._log.info("Estimated number of partitions: %d", nparts)
-        doc_index_to_name = [None] * len(self.document_indexer)
-        for k, i in self.document_indexer.value_to_index.items():
-            doc_index_to_name[i] = k
+        doc_index_to_name = {
+            index: name for name, index in self.document_indexer.value_to_index.items()}
         tokens = self.df.tokens()
         it = head \
             .map(lambda x: (x[c.document], (x[c.token], x[c.value]))) \

--- a/sourced/ml/transformers/indexer.py
+++ b/sourced/ml/transformers/indexer.py
@@ -1,6 +1,6 @@
 from typing import Union, Dict
 from pyspark.rdd import RDD
-from pyspark import Row, SparkContext
+from pyspark import Row
 
 from sourced.ml.transformers.transformer import Transformer
 from sourced.ml.models import DocumentFrequencies

--- a/sourced/ml/transformers/tfidf.py
+++ b/sourced/ml/transformers/tfidf.py
@@ -14,7 +14,7 @@ class TFIDF(Transformer):
     def __init__(self, df: dict, ndocs: int, sc: SparkContext, **kwargs):
         """
         :param df: dict containing document frequencies calculated for the given stream.
-        :param ndocs: total umber of documents
+        :param ndocs: total number of documents
         :param sc: spark context used to broadcast `df
         """
         super().__init__(**kwargs)
@@ -33,7 +33,7 @@ class TFIDF(Transformer):
         c = self.Columns
         df = self.sc.broadcast(self.df)
         ndocs = self.ndocs
-        head =  head \
+        head = head \
             .filter(lambda x: df.value.get(x[c.token]) is not None) \
             .map(lambda x: Row(**{
                 c.token: x[c.token],

--- a/sourced/ml/transformers/tfidf.py
+++ b/sourced/ml/transformers/tfidf.py
@@ -1,7 +1,6 @@
-from pyspark import Row
+from pyspark import Row, RDD, SparkContext
 
 from sourced.ml.algorithms import log_tf_log_idf
-from sourced.ml.models import DocumentFrequencies
 from sourced.ml.transformers.uast2bag_features import Uast2BagFeatures
 from sourced.ml.transformers.transformer import Transformer
 
@@ -12,22 +11,33 @@ class TFIDF(Transformer):
     """
     Columns = Uast2BagFeatures.Columns
 
-    def __init__(self, df: DocumentFrequencies, **kwargs):
+    def __init__(self, df: dict, ndocs: int, sc: SparkContext, **kwargs):
         """
-        :param tf: pyspark rdd where each row is named tuple with `token`, `document` and `value` \
-                   (term frequency) fields. One can use Uast2TermFreq Transformer to calculate \
-                   such rdd.
-        :param df: DocumentFrequencies model calculated for the given `tf` stream.
+        :param df: dict containing document frequencies calculated for the given stream.
+        :param ndocs: total umber of documents
+        :param sc: spark context used to broadcast `df
         """
         super().__init__(**kwargs)
         self.df = df
+        self.ndocs = ndocs
+        self.sc = sc
 
-    def __call__(self, head):
+    def __call__(self, head: RDD):
+        """
+
+        :param head: pyspark rdd where each row is named tuple with `token`, `document` and `value`
+                   (term frequency) fields. One can use Uast2TermFreq Transformer to calculate
+                   such rdd.
+        :return: rdd after applying TFIDF
+        """
         c = self.Columns
-        df = self.df
-        return head \
-            .filter(lambda x: df.get(x[c.token]) is not None) \
+        df = self.sc.broadcast(self.df)
+        ndocs = self.ndocs
+        head =  head \
+            .filter(lambda x: df.value.get(x[c.token]) is not None) \
             .map(lambda x: Row(**{
                 c.token: x[c.token],
                 c.document: x[c.document],
-                c.value: log_tf_log_idf(df=df[x[c.token]], tf=x[c.value], ndocs=df.docs)}))
+                c.value: log_tf_log_idf(df=df.value[x[c.token]], tf=x[c.value], ndocs=ndocs)}))
+        df.unpersist(blocking=True)
+        return head

--- a/sourced/ml/utils/docfreq.py
+++ b/sourced/ml/utils/docfreq.py
@@ -4,7 +4,7 @@ from sourced.ml.transformers import BagFeatures2DocFreq, Uast2BagFeatures
 from sourced.ml.models import OrderedDocumentFrequencies
 
 
-def create_or_load_ordered_df(args, ndocs: int, bag_features: Uast2BagFeatures):
+def create_or_load_ordered_df(args, ndocs: int=None, bag_features: Uast2BagFeatures=None):
     """
     Returns a preexisting OrderedDocumentFrequencies model from docfreq_in, or generates one
     from the flattened bags of features using args and saves it to docfreq_out.
@@ -21,6 +21,9 @@ def create_or_load_ordered_df(args, ndocs: int, bag_features: Uast2BagFeatures):
     if args.docfreq_in:
         log.info("Loading ordered docfreq model from %s ...", args.docfreq_in)
         return OrderedDocumentFrequencies().load(args.docfreq_in)
+    elif ndocs is None or bag_features is None:
+        log.error("[IN] only mode, please supply an ordered docfreq model")
+        raise ValueError
     log.info("Calculating the document frequencies, hold tight ...")
     df = bag_features \
         .link(BagFeatures2DocFreq()) \

--- a/sourced/ml/utils/quant.py
+++ b/sourced/ml/utils/quant.py
@@ -12,8 +12,13 @@ def create_or_apply_quant(model_path: str, extractors: List[BagsExtractor], extr
     if os.path.exists(model_path):
         log.info("Loading the quantization levels from %s and applying quantization to supported"
                  " extractors...", model_path)
-        QuantizationLevels().load(source=model_path).apply_quantization(extractors)
-    elif extracted_uasts is None:
+        try:
+            QuantizationLevels().load(source=model_path).apply_quantization(extractors)
+        except (ValueError, ImportError):
+            pass
+        else:
+            return
+    if extracted_uasts is None:
         log.error("[IN] only mode, please supply a quantization levels model")
         raise ValueError
     else:

--- a/sourced/ml/utils/quant.py
+++ b/sourced/ml/utils/quant.py
@@ -10,7 +10,12 @@ from sourced.ml.extractors import BagsExtractor
 def create_or_apply_quant(model_path: str, extractors: List[BagsExtractor], extracted_uasts=None):
     log = logging.getLogger("create_or_apply_quant")
     if os.path.exists(model_path):
+        log.info("Loading the quantization levels from %s and applying quantization to supported"
+                 " extractors...", model_path)
         QuantizationLevels().load(source=model_path).apply_quantization(extractors)
+    elif extracted_uasts is None:
+        log.error("[IN] only mode, please supply a quantization levels model")
+        raise ValueError
     else:
         quant = Uast2Quant(extractors)
         extracted_uasts.link(quant).execute()


### PR DESCRIPTION
### CONTEXT:

So, again on this. Thought the previous PR was enough, but there were two shortcoming:
- we still had to run repos2bow subdir by subdir, either manually or through bash loops
- on PGA still got OOM errors

### CHANGES:

**1st commit:**

I added broadcasting in `TFIDF` and `Indexer`transformers, to speed up process and avoid OOM. I removed `cached_index_path`  in `Indexer`'s `__init__` because it was kind of redundant with the `column2id` param. I also replaced in both transformers the use of the model with dicts, because the broadcasting of whole models is more costly.

**2nd commit:**

Even though we can't hold all extracted features at one or we get OOM errors, we can save on disk all of PGA and then iterate on partitions to run the pipeline - as long as TFIDF is done intelligently. To do so we partition the data by document with `PartitionBy` transformer I added, then select by partition number with `PartitionSelector`. 

**3rd commit:**

I use the new or modified transformers in repos2bow. Now `repos2bow_index` must have been run previously to run `repos2bow`, I added `ValueErrors` to `docfreq`and `quant` utilitaries. To choose the number of iterations I added a `num-iterations` flag. I added an `uncache`  method to `Cacher` so Spark doesn't waste memory on data cached in a previous iteration.

The pipeline is now:

1. Load `docfreq.asdf`, `index.asdf`, `quant.asdf` if needed, all created w/ `repos2bow_index`.
2. `PartitionBy` on all the data then cache it on disk (takes about an hour for PGA divided in 500)
3. Iterate through all partitions:

```
# first write meta table
INFO:MetadataSaver:ParquetLoader -> Moder -> PartitionBy -> Cacher -> PartitionSelector 
-> Repartitioner -> Cacher -> MetadataSaver

# then collect documents in that partition to reduce size of broadcasted doc index:
INFO:Collector:ParquetLoader -> Moder -> PartitionBy -> Cacher -> PartitionSelector 
-> Repartitioner -> Cacher -> UastRow2Document -> Cacher ->  FieldsSelector 
-> Distinct -> Collector

# then collect distinct tokens to reduce size of broadcasted token_index / token df
INFO:Collector:ParquetLoader -> Moder -> PartitionBy -> Cacher -> PartitionSelector 
-> Repartitioner -> Cacher -> UastRow2Document -> Cacher -> UastDeserializer 
-> Uast2BagFeatures -> BagFeatures2TermFreq -> Cacher -> FieldsSelector 
-> Distinct -> Collector

# then write bags
INFO: BOWWriter:ParquetLoader -> Moder -> PartitionBy -> Cacher -> PartitionSelector 
-> Repartitioner -> Cacher -> UastRow2Document -> Cacher -> UastDeserializer 
-> Uast2BagFeatures -> BagFeatures2TermFreq -> Cacher -> TFIDF -> Indexer (doc)
-> Indexer (token) -> Repartitioner -> BagsSaver -> PartitionBy -> BOWWriter
```

**RESULTS ON PGA:**

I am running with 500 iterations, it took about an hour to cache all the data to disk (197GB), then each iteration runs in about 10 minutes, and writes 170MB -> job should run in ~85h and write 85GB to disk