### PR TITLE
Add __rshift__ __lshift__ shortcuts for link and unlink transformers

### DIFF
--- a/sourced/ml/tests/test_basic_transformers.py
+++ b/sourced/ml/tests/test_basic_transformers.py
@@ -6,9 +6,8 @@ from pyspark.sql import Row
 
 from sourced.ml.utils import create_engine
 from sourced.ml.transformers import ParquetSaver, ParquetLoader, Collector, First, \
-     Identity, FieldsSelector, Repartitioner, DzhigurdaFiles, Execute, Explode
+     Identity, FieldsSelector, Repartitioner, DzhigurdaFiles
 from sourced.ml.tests.models import PARQUET_DIR, SIVA_DIR
-from sourced.ml.tests.test_transformer import DumpTransformer
 
 
 class BasicTransformerTest(unittest.TestCase):
@@ -92,30 +91,6 @@ class BasicTransformerTest(unittest.TestCase):
         row = FieldsSelector(fields=["name", "age"])(df.rdd).first()
         self.assertTrue(hasattr(row, "age"))
         self.assertTrue(hasattr(row, "name"))
-
-    def test_execute(self):
-        DumpTransformer.call_ids = []
-        t1 = DumpTransformer(1)
-        t2 = DumpTransformer(2)
-        t3 = DumpTransformer(3)
-
-        t1 >> t2 >> t3 >> Execute()
-        self.assertEqual(DumpTransformer.call_ids, [1, 2, 3])
-
-    def test_explode(self):
-        DumpTransformer.call_ids = []
-        t1 = DumpTransformer(1)
-        t2 = DumpTransformer(2)
-        t31 = DumpTransformer(31)
-        t32 = DumpTransformer(32)
-
-        t1 >> t2 >> (t31, t32)
-        t1 >> Explode()
-        self.assertEqual(DumpTransformer.call_ids, [1, 2, 31, 32])
-
-        DumpTransformer.call_ids = []
-        t32 >> Explode()
-        self.assertEqual(DumpTransformer.call_ids, [1, 2, 32])
 
 
 if __name__ == '__main__':

--- a/sourced/ml/transformers/__init__.py
+++ b/sourced/ml/transformers/__init__.py
@@ -4,7 +4,7 @@ from sourced.ml.transformers.basic import Sampler, Collector, First, Identity, C
     UastDeserializer, Counter, create_uast_source, CsvSaver, LanguageSelector, DzhigurdaFiles
 from sourced.ml.transformers.indexer import Indexer
 from sourced.ml.transformers.tfidf import TFIDF
-from sourced.ml.transformers.transformer import Execute, Explode, LeafTransformer, Transformer
+from sourced.ml.transformers.transformer import Transformer, Execute
 from sourced.ml.transformers.uast2bag_features import Uast2BagFeatures, UastRow2Document
 from sourced.ml.transformers.uast2quant import Uast2Quant
 from sourced.ml.transformers.bag_features2docfreq import BagFeatures2DocFreq

--- a/sourced/ml/transformers/__init__.py
+++ b/sourced/ml/transformers/__init__.py
@@ -4,7 +4,7 @@ from sourced.ml.transformers.basic import Sampler, Collector, First, Identity, C
     UastDeserializer, Counter, create_uast_source, CsvSaver, LanguageSelector, DzhigurdaFiles
 from sourced.ml.transformers.indexer import Indexer
 from sourced.ml.transformers.tfidf import TFIDF
-from sourced.ml.transformers.transformer import Transformer
+from sourced.ml.transformers.transformer import Execute, Explode, LeafTransformer, Transformer
 from sourced.ml.transformers.uast2bag_features import Uast2BagFeatures, UastRow2Document
 from sourced.ml.transformers.uast2quant import Uast2Quant
 from sourced.ml.transformers.bag_features2docfreq import BagFeatures2DocFreq


### PR DESCRIPTION
As was discussed here: https://github.com/src-d/ml/pull/284#discussion_r200116805 we decided to add code that will allow us to write  pipelines like:
```python
Ignition(engine) >> HeadFiles() >> LanguageSelector() >> Execute()
```

This PR contains main changes to allow this. Note, that I also add `<<` for `unlink()` method.

Also, I modify `link()` function to allow multiple likage. Example:
```
t1 = DumpTransformer(1)
t2 = DumpTransformer(2)
t31 = DumpTransformer(31)
t32 = DumpTransformer(32)

t1 >> t2 >> (t31, t32)
t1 >> Explode()
```
It creates and executes a tree:
```
t1 - t2 - t31
      \
       t32
```

To be able to use `>> Execute()` and `>> Explode()` I create special `LeafTransformer`s that cannot be connected to anything else and marks that it is time to execute pipeline. I think it is a most simple way to implement it.

As soon as this PR will be merged, I plan to rewrite our pipelines via `>>`.