### PR TITLE
Add merge bow function

### DIFF
--- a/sourced/ml/__main__.py
+++ b/sourced/ml/__main__.py
@@ -5,7 +5,7 @@ import sys
 
 from modelforge.logs import setup_logging
 
-from sourced.ml.extractors import IdentifierDistance
+from sourced.ml import extractors
 from sourced.ml.transformers import Moder
 from sourced.ml import cmd
 from sourced.ml.cmd import args
@@ -121,10 +121,10 @@ def get_parser() -> argparse.ArgumentParser:
     args.add_repo2_args(repos2identifier_distance)
     args.add_split_stem_arg(repos2identifier_distance)
     repos2identifier_distance.add_argument(
-        "-t", "--type", required=True, choices=IdentifierDistance.DistanceType.All,
+        "-t", "--type", required=True, choices=extractors.IdentifierDistance.DistanceType.All,
         help="Distance type.")
     repos2identifier_distance.add_argument(
-        "--max-distance", default=IdentifierDistance.DEFAULT_MAX_DISTANCE, type=int,
+        "--max-distance", default=extractors.IdentifierDistance.DEFAULT_MAX_DISTANCE, type=int,
         help="Maximum distance to save.")
     repos2identifier_distance.add_argument(
         "-o", "--output", required=True,
@@ -274,9 +274,8 @@ def get_parser() -> argparse.ArgumentParser:
     bigartm_parser.add_argument("--output", default=os.getcwd(), help="Output directory.")
 
     # ------------------------------------------------------------------------
-    merge_df = add_parser("merge-df", "Merge DocumentFrequencies models to a singe one.")
+    merge_df = add_parser("merge-df", "Merge DocumentFrequencies models to a single one.")
     merge_df.set_defaults(handler=cmd.merge_df)
-    args.add_filter_arg(merge_df)
     args.add_min_docfreq(merge_df)
     args.add_vocabulary_size_arg(merge_df)
     merge_df.add_argument(
@@ -294,7 +293,6 @@ def get_parser() -> argparse.ArgumentParser:
     merge_coocc = add_parser("merge-coocc", "Merge several Cooccurrences models together.")
     merge_coocc.set_defaults(handler=cmd.merge_coocc)
     add_spark_args(merge_coocc)
-    args.add_filter_arg(merge_coocc)
     merge_coocc.add_argument(
         "-o", "--output", required=True,
         help="Path to the merged Cooccurrences model.")
@@ -310,6 +308,20 @@ def get_parser() -> argparse.ArgumentParser:
         "--no-spark", action="store_true", default=False,
         help="Use the local reduction instead of PySpark. "
              "Can be faster and consume less memory if the data fits into RAM.")
+    # ------------------------------------------------------------------------
+    merge_bow = add_parser("merge-bow", "Merge BOW models to a single one.")
+    merge_bow.set_defaults(handler=cmd.merge_bow)
+    merge_bow.add_argument(
+        "-i", "--input", required=True, nargs="+",
+        help="BOW models input files."
+             "Use `-i -` to read input files from stdin.")
+    merge_bow.add_argument(
+        "-o", "--output", required=True,
+        help="Path to the merged BOW model.")
+    merge_bow.add_argument(
+        "-f", "--features", nargs="+",
+        choices=[ex.NAME for ex in extractors.__extractors__.values()],
+        default=None, help="To keep only specific features, if not specified all will be kept.")
     return parser
 
 

--- a/sourced/ml/cmd/__init__.py
+++ b/sourced/ml/cmd/__init__.py
@@ -4,6 +4,7 @@ from sourced.ml.cmd.bigartm2asdf import bigartm2asdf
 from sourced.ml.cmd.bow_converters import bow2vw
 from sourced.ml.cmd.merge_df import merge_df
 from sourced.ml.cmd.merge_coocc import merge_coocc
+from sourced.ml.cmd.merge_bow import merge_bow
 from sourced.ml.cmd.id2vec_postprocess import id2vec_postprocess
 from sourced.ml.cmd.id2vec_preprocess import id2vec_preprocess
 from sourced.ml.cmd.preprocess_repos import preprocess_repos

--- a/sourced/ml/cmd/args.py
+++ b/sourced/ml/cmd/args.py
@@ -10,9 +10,6 @@ from sourced.ml.transformers import BOWWriter, Moder
 from sourced.ml.utils import add_engine_args
 
 
-DEFAULT_FILTER_ARG = "**/*.asdf"
-
-
 class ArgumentDefaultsHelpFormatterNoNone(argparse.ArgumentDefaultsHelpFormatter):
     """
     Pretty formatter of help message for arguments.
@@ -135,8 +132,3 @@ def add_dzhigurda_arg(my_parser):
              "commits. 0 corresponds to HEAD only commits, 1 to HEAD and HEAD~1, 2 to HEAD, HEAD~1"
              " and HEAD~2, etc. With `--dzhigurda -1` we keep all possible commits for each "
              "document.")
-
-
-def add_filter_arg(my_parser: argparse.ArgumentParser):
-    my_parser.add_argument(
-        "--filter", default=DEFAULT_FILTER_ARG, help="File name glob selector.")

--- a/sourced/ml/cmd/merge_bow.py
+++ b/sourced/ml/cmd/merge_bow.py
@@ -1,0 +1,9 @@
+import logging
+
+from sourced.ml.models import MergeBOW
+from sourced.ml.cmd.args import handle_input_arg
+
+
+def merge_bow(args):
+    log = logging.getLogger("merge_bow")
+    MergeBOW(args.features).convert(handle_input_arg(args.input, log), args.output)

--- a/sourced/ml/models/__init__.py
+++ b/sourced/ml/models/__init__.py
@@ -9,3 +9,4 @@ from sourced.ml.models.topics import Topics
 from sourced.ml.models.quant import QuantizationLevels
 
 from sourced.ml.models.model_converters.merge_df import MergeDocFreq
+from sourced.ml.models.model_converters.merge_bow import MergeBOW

--- a/sourced/ml/models/model_converters/base.py
+++ b/sourced/ml/models/model_converters/base.py
@@ -29,14 +29,13 @@ class Model2Base(PickleableLogger):
         self.num_processes = multiprocessing.cpu_count() if num_processes == 0 else num_processes
         self.overwrite_existing = overwrite_existing
 
-    def convert(self, models_path: List[str], destdir: str, pattern: str="**/*.asdf") -> int:
+    def convert(self, models_path: List[str], destdir: str) -> int:
         """
         Performs the model -> model conversion. Runs the conversions in a pool of processes.
 
-        :param srcdir: List of Models path.
+        :param models_path: List of Models path.
         :param destdir: The directory where to store the models. The directory structure is \
                         preserved.
-        :param pattern: glob pattern for the files.
         :return: The number of converted files.
         """
         files = list(models_path)
@@ -114,12 +113,3 @@ class Model2Base(PickleableLogger):
 
     def _get_log_name(self):
         return "%s2%s" % (self.MODEL_FROM_CLASS.NAME, self.MODEL_TO_CLASS.NAME)
-
-    def _get_model_path(self, path):
-        """
-        By default, we name the converted files exactly the same.
-
-        :param path: The path relative to ``srcdir``.
-        :return: The target path for the converted model.
-        """
-        return path

--- a/sourced/ml/models/model_converters/merge_bow.py
+++ b/sourced/ml/models/model_converters/merge_bow.py
@@ -1,0 +1,68 @@
+import os
+from scipy.sparse import vstack
+
+from sourced.ml import extractors
+from sourced.ml.models.bow import BOW
+from sourced.ml.models.model_converters.base import Model2Base
+
+
+class MergeBOW(Model2Base):
+    """
+    Merges several :class:`BOW` models together.
+    """
+    MODEL_FROM_CLASS = BOW
+    MODEL_TO_CLASS = BOW
+
+    def __init__(self, features=None, *args, **kwargs):
+        super().__init__(num_processes=1, *args, **kwargs)
+        self.documents = None
+        self.tokens = None
+        self.matrix = None
+        self.deps = None
+        self.features_namespaces = None
+        if features:
+            self.features_namespaces = [ex.NAMESPACE for ex in extractors.__extractors__.values()
+                                        if ex.NAME in features]
+
+    def convert_model(self, model: BOW) -> None:
+        if self.tokens is None:
+            self.tokens = model.tokens
+            self.documents = model.documents
+            self.matrix = [model.matrix.tocsr()]
+            self.deps = model._meta["dependencies"]
+        elif set(self.tokens) != set(model.tokens):
+            raise ValueError("Models don't share the same set of tokens !")
+        else:
+            self.documents += model.documents
+            self.matrix.append(model.matrix.tocsr())
+
+    def finalize(self, index: int, destdir: str):
+        self._log.info("Stacking matrices ...")
+        matrix = self.matrix.pop(0)
+        while self.matrix:
+            matrix = vstack([matrix, self.matrix.pop(0)])
+            self._log.info("%s matrices to stack ...", len(self.matrix))
+        self.matrix = matrix
+        self._log.info("Writing model ...")
+        if self.features_namespaces:
+            self._reduce_matrix()
+        BOW(log_level=self._log.level) \
+            .construct(self.documents, self.tokens, self.matrix) \
+            .save(self._save_path(index, destdir), self.deps)
+
+    def _reduce_matrix(self):
+        reduced_tokens = []
+        columns = []
+        matrix = self.matrix.tocsc()
+        for i, token in enumerate(self.tokens):
+            if token.split(".")[0] in self.features_namespaces:
+                reduced_tokens.append(token)
+                columns.append(i)
+        self.tokens = reduced_tokens
+        self.matrix = matrix[:, columns]
+
+    @staticmethod
+    def _save_path(index: int, destdir: str):
+        if destdir.endswith(".asdf"):
+            return destdir
+        return os.path.join(destdir, "bow_%d.asdf" % index)

--- a/sourced/ml/models/model_converters/merge_df.py
+++ b/sourced/ml/models/model_converters/merge_df.py
@@ -1,8 +1,5 @@
 from collections import defaultdict
 import os
-from typing import Union
-
-from modelforge import Model
 
 from sourced.ml.models.model_converters.base import Model2Base
 from sourced.ml.models.df import DocumentFrequencies
@@ -16,7 +13,8 @@ class MergeDocFreq(Model2Base):
     MODEL_FROM_CLASS = DocumentFrequencies
     MODEL_TO_CLASS = DocumentFrequencies
 
-    def __init__(self, min_docfreq, vocabulary_size, ordered=False, *args, **kwargs):
+    def __init__(self, min_docfreq: int, vocabulary_size: int, ordered: bool=False,
+                 *args, **kwargs):
         super().__init__(num_processes=1, *args, **kwargs)
         self.ordered = ordered
         self.min_docfreq = min_docfreq
@@ -24,7 +22,7 @@ class MergeDocFreq(Model2Base):
         self._df = defaultdict(int)
         self._docs = 0
 
-    def convert_model(self, model: Model) -> Union[Model, None]:
+    def convert_model(self, model: DocumentFrequencies) -> None:
         for word, freq in model:
             self._df[word] += freq
         self._docs += model.docs

--- a/sourced/ml/tests/test_main.py
+++ b/sourced/ml/tests/test_main.py
@@ -30,6 +30,7 @@ class MainTests(unittest.TestCase):
             "preprocrepos": "preprocess_repos",
             "merge-df": "merge_df",
             "merge-coocc": "merge_coocc",
+            "merge-bow": "merge_bow",
         }
         parser = main.get_parser()
         subcommands = set([x.dest for x in parser._subparsers._actions[2]._choices_actions])

--- a/sourced/ml/tests/test_merge_bow.py
+++ b/sourced/ml/tests/test_merge_bow.py
@@ -1,0 +1,84 @@
+import os
+import tempfile
+import unittest
+import numpy as np
+from scipy.sparse import csc_matrix
+
+from sourced.ml.models import BOW
+from sourced.ml.models.model_converters.merge_bow import MergeBOW
+
+
+class MergeBOWTests(unittest.TestCase):
+    def setUp(self):
+        self.model1 = BOW() \
+            .construct(["doc_1", "doc_2", "doc_3"], ["f.tok_1", "k.tok_2", "f.tok_3"],
+                       csc_matrix((np.array([1, 2]), (np.array([0, 1]), np.array([1, 0]))),
+                                  shape=(3, 3)))
+        self.model1._meta = {"dependencies": [{"model": "docfreq", "uuid": "uuid"}]}
+        self.model2 = BOW() \
+            .construct(["doc_4", "doc_5", "doc_6"], ["f.tok_1", "k.tok_2", "f.tok_3"],
+                       csc_matrix((np.array([3, 4]), (np.array([0, 1]), np.array([1, 0]))),
+                                  shape=(3, 3)))
+        self.model2._meta = {"dependencies": [{"model": "docfreq", "uuid": "uuid"}]}
+        self.merge_results = [[0, 1, 0], [2, 0, 0], [0, 0, 0], [0, 3, 0], [4, 0, 0], [0, 0, 0]]
+        self.merge_bow = MergeBOW()
+
+    def test_convert_model_base(self):
+        self.merge_bow.convert_model(self.model1)
+        self.assertListEqual(self.merge_bow.documents, ["doc_1", "doc_2", "doc_3"])
+        self.assertListEqual(self.merge_bow.tokens, ["f.tok_1", "k.tok_2", "f.tok_3"])
+        for i, row in enumerate(self.merge_bow.matrix[0].toarray()):
+            self.assertListEqual(list(row), self.merge_results[i])
+        self.assertEqual(self.merge_bow.deps, [{'uuid': 'uuid', 'model': 'docfreq'}])
+        self.merge_bow.convert_model(self.model2)
+        self.assertListEqual(self.merge_bow.documents,
+                             ["doc_1", "doc_2", "doc_3", "doc_4", "doc_5", "doc_6"])
+        self.assertListEqual(self.merge_bow.tokens, ["f.tok_1", "k.tok_2", "f.tok_3"])
+        for i, arr in enumerate(self.merge_bow.matrix):
+            for j, row in enumerate(arr.toarray()):
+                self.assertListEqual(list(row), self.merge_results[i * 3 + j])
+        self.assertEqual(self.merge_bow.deps, [{"model": "docfreq", "uuid": "uuid"}])
+
+    def test_convert_model_error(self):
+        self.merge_bow.convert_model(self.model1)
+        self.model2._tokens = ["f.tok_1", "k.tok_2"]
+        with self.assertRaises(ValueError):
+            self.merge_bow.convert_model(self.model2)
+        self.model2._tokens = ["f.tok_1", "k.tok_2", "f.tok_3", "f.tok_4"]
+        with self.assertRaises(ValueError):
+            self.merge_bow.convert_model(self.model2)
+
+    def test_finalize_base(self):
+        self.merge_bow.convert_model(self.model1)
+        self.merge_bow.convert_model(self.model2)
+        with tempfile.TemporaryDirectory(prefix="merge-bow-") as tmpdir:
+            dest = os.path.join(tmpdir, "bow.asdf")
+            self.merge_bow.finalize(0, dest)
+            bow = BOW().load(dest)
+            self.assertListEqual(bow.documents,
+                                 ["doc_1", "doc_2", "doc_3", "doc_4", "doc_5", "doc_6"])
+            self.assertListEqual(bow.tokens, ["f.tok_1", "k.tok_2", "f.tok_3"])
+            for i, row in enumerate(bow.matrix.toarray()):
+                self.assertListEqual(list(row), self.merge_results[i])
+            self.assertEqual(bow.meta["dependencies"], [{'uuid': 'uuid', 'model': 'docfreq'}])
+
+    def test_finalize_reduce(self):
+        self.merge_bow.convert_model(self.model1)
+        self.merge_bow.features_namespaces = "f."
+        with tempfile.TemporaryDirectory(prefix="merge-bow-") as tmpdir:
+            dest = os.path.join(tmpdir, "bow.asdf")
+            self.merge_bow.finalize(0, dest)
+            bow = BOW().load(dest)
+            self.assertListEqual(bow.documents, ["doc_1", "doc_2", "doc_3"])
+            self.assertListEqual(bow.tokens, ["f.tok_1", "f.tok_3"])
+            for i, row in enumerate(bow.matrix.toarray()):
+                self.assertListEqual(list(row), self.merge_results[i][::2])
+            self.assertEqual(bow.meta["dependencies"], [{'uuid': 'uuid', 'model': 'docfreq'}])
+
+    def test_save_path(self):
+        self.assertEqual(self.merge_bow._save_path(0, "bow.asdf"), "bow.asdf")
+        self.assertEqual(self.merge_bow._save_path(0, "bow"), os.path.join("bow", "bow_0.asdf"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sourced/ml/tests/test_merge_df.py
+++ b/sourced/ml/tests/test_merge_df.py
@@ -6,40 +6,19 @@ from sourced.ml.models import DocumentFrequencies
 from sourced.ml.models.model_converters.merge_df import MergeDocFreq
 
 
-class FakeModel:
-    def __init__(self, df):
-        self.df = df
-        self.docs = 1
-
-    def __iter__(self):
-        yield from self.df.items()
-
-
 class Model2BaseTests(unittest.TestCase):
     def setUp(self):
-        self.model1 = FakeModel({
-                "one": 1,
-                "two": 2,
-                "three": 3,
-            })
-        self.model2 = FakeModel({
-                "four": 4,
-                "three": 3,
-                "five": 5,
-            })
+        self.model1 = DocumentFrequencies().construct(3, {"one": 1, "two": 2,  "three": 3})
+        self.model2 = DocumentFrequencies().construct(3, {"four": 4, "three": 3, "five": 5})
         self.merge_df = MergeDocFreq(min_docfreq=1, vocabulary_size=100)
-        self.merge_result = {"one": 1,
-                             "two": 2,
-                             "three": 6,
-                             "four": 4,
-                             "five": 5}
+        self.merge_result = {"one": 1, "two": 2,  "three": 6, "four": 4, "five": 5}
 
     def test_convert_model(self):
         self.merge_df.convert_model(self.model1)
-        self.assertEqual(self.merge_df._docs, 1)
-        self.assertEqual(self.merge_df._df, self.model1.df)
+        self.assertEqual(self.merge_df._docs, 3)
+        self.assertEqual(self.merge_df._df, self.model1._df)
         self.merge_df.convert_model(self.model2)
-        self.assertEqual(self.merge_df._docs, 2)
+        self.assertEqual(self.merge_df._docs, 6)
         self.assertEqual(self.merge_df._df, self.merge_result)
 
     def test_finalize(self):
@@ -47,9 +26,9 @@ class Model2BaseTests(unittest.TestCase):
         self.merge_df.convert_model(self.model2)
         with tempfile.TemporaryDirectory(prefix="merge-df-") as tmpdir:
             dest = os.path.join(tmpdir, "df.asdf")
-            self.merge_df.finalize(None, dest)
+            self.merge_df.finalize(0, dest)
             df = DocumentFrequencies().load(dest)
-            self.assertEqual(df.docs, 2)
+            self.assertEqual(df.docs, 6)
             self.assertEqual(df._df, self.merge_result)
 
     def test_save_path(self):

--- a/sourced/ml/tests/test_model2base.py
+++ b/sourced/ml/tests/test_model2base.py
@@ -72,8 +72,7 @@ class Model2BaseTests(unittest.TestCase):
     def test_convert(self):
         converter = Model2Test(num_processes=2)
         with tempfile.TemporaryDirectory() as tmpdir:
-            status = converter.convert(os.listdir(os.path.dirname(__file__)), tmpdir,
-                                       pattern="**/*.py")
+            status = converter.convert(os.listdir(os.path.dirname(__file__)), tmpdir)
             self.assertGreater(status, 20)
 
     def test_process_entry(self):


### PR DESCRIPTION
We have command for merging `docfreq` models, this implements the same thing for `bow` models. I think it is useful because on large inputs of data we can't collect all of them at once and create small batches of bags due to Spark limitations, however it is cumbersome to move around dozen or hundreds of those, and not compact. I also implemented a function to reduce the output bag by keeping only user selected features (default is all). I did that because it ill probably be useful for users, especially if they are downloading the model but only want specific(s) features, however not sure whether it shouldn't also be a method of the BOW model itself, if yes tell me and I'll change structure. I also removed some unused stuff that we forgot to take out.