### PR TITLE
Fix requirements for python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Cython>=0.28,<1.0; python_version == '3.7'
 PyStemmer>=1.3,<2.0
 bblfsh>=2.2.1,<3.0
 modelforge==0.7.0


### PR DESCRIPTION
Related issue: https://github.com/src-d/ml/issues/318
Make 
```
pip3 install -r requirements.txt
pip3 install .
```
works.