### PR TITLE
setup.py: Add long_description and python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     tests_require=["docker>=3.4.0,<4.0"],
     package_data={"": ["LICENSE.md", "README.md"],
                   "sourced": ["ml/transformers/languages.yml"], },
+    python_requires=">=3.4",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Console",

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@ import sys
 
 sourcedml = SourceFileLoader("sourced.ml", "./sourced/ml/__init__.py").load_module()
 
+with open("README.md") as f:
+    long_description = f.read()
+
 if sys.version_info < (3, 5, 0):
     typing = ["typing"]
 else:
@@ -14,6 +17,8 @@ setup(
     description="Framework for machine learning on source code. "
                 "Provides API and tools to train and use models based "
                 "on source code features extracted from Babelfish's UASTs.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     version=".".join(map(str, sourcedml.__version__)),
     license="Apache 2.0",
     author="source{d}",


### PR DESCRIPTION
The description is missing at https://pypi.org/project/sourced-ml/:

![image](https://user-images.githubusercontent.com/1324225/46572150-b342c480-c989-11e8-9e8c-5bf1f0fd7e9a.png)

This PR adds it, using README.md. See https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi for instructions, the main thing is to make sure to use recent twine and setuptools for upload: `pip install -U twine setuptools`.

---

Also, add `python_requires` to help pip install the right version for the user's Python version.
 
More info on how this works:
* https://packaging.python.org/guides/dropping-older-python-versions/
* https://hackernoon.com/phasing-out-python-runtimes-gracefully-956f112f33c4
