### PR TITLE
Open README with utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,12 @@
+import io
 import os.path
 from importlib.machinery import SourceFileLoader
 from setuptools import setup, find_packages
 
 sourcedml = SourceFileLoader("sourced.ml", "./sourced/ml/__init__.py").load_module()
 
-with open(os.path.join(os.path.dirname(__file__), "README.md")) as f:
+with io.open(os.path.join(os.path.dirname(__file__), "README.md"),
+             encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
Signed-off-by: Nikita Titov <nekit94-08@mail.ru>

This fix prevents the crash during the installation on machines with non-standard locales:
https://github.com/RGF-team/rgf/issues/65
https://github.com/henry0312/pytest-codestyle/pull/34