### PR TITLE
Move pandas from requirements to extras

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ _install: &_install
   - gimme 1.8
   - source ~/.gimme/envs/latest.env
   - pip install --upgrade pip
-  - if [[ $TRAVIS_PYTHON_VERSION < 3.7 ]]; then pip install [tf]; fi
+  - if [[ $TRAVIS_PYTHON_VERSION < 3.7 ]]; then pip install tensorflow; fi
   - pip install -r requirements.txt codecov
   - pip install -e .[pandas]
 _coverage: &_coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ _install: &_install
   - gimme 1.8
   - source ~/.gimme/envs/latest.env
   - pip install --upgrade pip
-  - if [[ $TRAVIS_PYTHON_VERSION < 3.7 ]]; then pip install tensorflow; fi
+  - if [[ $TRAVIS_PYTHON_VERSION < 3.7 ]]; then pip install [tf]; fi
   - pip install -r requirements.txt codecov
-  - pip install -e .
+  - pip install -e .[pandas]
 _coverage: &_coverage
   - SCRIPT="coverage run --concurrency=multiprocessing -m unittest discover && coverage combine"
 _deploy: &_deploy

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,5 @@ numpy>=1.14
 humanize>=0.5.0,<0.6
 pygments>=2.2.0,<3.0
 keras>=2.0,<3.0
-pandas>=0.22,<1.0
 scikit-learn>=0.19,<1.0
 tqdm>=4.20,<5.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         "parquet>=1.2,<2.0",
         "pygments>=2.2.0,<3.0",
         "keras>=2.0,<3.0",
-        "pandas>=0.22,<1.0",
         "scikit-learn>=0.19,<1.0",
         "tqdm>=4.20,<5.0",
         "typing;python_version<'3.5'",
@@ -46,6 +45,7 @@ setup(
     extras_require={
         "tf": ["tensorflow>=1.0,<2.0"],
         "tf_gpu": ["tensorflow-gpu>=1.0,<2.0"],
+        "pandas": ["pandas>=0.22,<1.0"],
     },
     tests_require=["docker>=3.4.0,<4.0"],
     package_data={"": ["LICENSE.md", "README.md"],

--- a/sourced/ml/algorithms/swivel.py
+++ b/sourced/ml/algorithms/swivel.py
@@ -58,7 +58,7 @@ import os
 import time
 import threading
 
-import numpy as np
+import numpy
 import tensorflow as tf
 from tensorflow.python.client import device_lib
 
@@ -249,7 +249,7 @@ class SwivelModel:
             tf.summary.histogram("row_emb", self.row_embedding)
             tf.summary.histogram("col_emb", self.col_embedding)
 
-            matrix_log_sum = math.log(np.sum(row_sums) + 1)
+            matrix_log_sum = math.log(numpy.sum(row_sums) + 1)
             row_bias_init = [math.log(x + 1) for x in row_sums]
             col_bias_init = [math.log(x + 1) for x in col_sums]
             self.row_bias = tf.Variable(

--- a/sourced/ml/cmd/id2role_eval.py
+++ b/sourced/ml/cmd/id2role_eval.py
@@ -2,8 +2,8 @@ import glob
 import logging
 import os
 
-import numpy as np
-import pandas as pd
+import numpy
+import pandas
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split, KFold, GridSearchCV
 from tqdm import tqdm
@@ -16,8 +16,8 @@ def load_dataset(directory):
     csvpaths = glob.glob(os.path.join(directory, "**/*.csv"))
     chunks = []
     for csvpath in tqdm(csvpaths):
-        chunks.append(pd.read_csv(csvpath, sep=',', index_col=None))
-    df = pd.concat(chunks)
+        chunks.append(pandas.read_csv(csvpath, sep=',', index_col=None))
+    df = pandas.concat(chunks)
     df.role = df.role.map(lambda x: x.replace("IDENTIFIER | ", "").replace(" | IDENTIFIER", ""))
     return df
 
@@ -34,7 +34,7 @@ def identifiers_to_datasets(df_unique, id2vecs, log):
         X = []
         for key in identifiers:
             X.append(id2vec.embeddings[id2vec[key]])
-        Xs[name] = np.array(X)
+        Xs[name] = numpy.array(X)
 
     return Xs, y
 
@@ -101,7 +101,7 @@ def id2role_eval(args):
     log.debug("Convert words to its embeddings")
     Xs, y = identifiers_to_datasets(df_unique, models, log)
 
-    final_report = pd.DataFrame(columns=["embedding name", "score", "best C value"])
+    final_report = pandas.DataFrame(columns=["embedding name", "score", "best C value"])
     for name in tqdm(Xs):
         log.info("{}...".format(name))
         best_values = get_quality(Xs[name], y,

--- a/sourced/ml/tests/test_merge_bow.py
+++ b/sourced/ml/tests/test_merge_bow.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 import unittest
-import numpy as np
+import numpy
 from scipy.sparse import csc_matrix
 
 from sourced.ml.models import BOW
@@ -12,12 +12,14 @@ class MergeBOWTests(unittest.TestCase):
     def setUp(self):
         self.model1 = BOW() \
             .construct(["doc_1", "doc_2", "doc_3"], ["f.tok_1", "k.tok_2", "f.tok_3"],
-                       csc_matrix((np.array([1, 2]), (np.array([0, 1]), np.array([1, 0]))),
+                       csc_matrix((numpy.array([1, 2]),
+                                  (numpy.array([0, 1]), numpy.array([1, 0]))),
                                   shape=(3, 3)))
         self.model1._meta = {"dependencies": [{"model": "docfreq", "uuid": "uuid"}]}
         self.model2 = BOW() \
             .construct(["doc_4", "doc_5", "doc_6"], ["f.tok_1", "k.tok_2", "f.tok_3"],
-                       csc_matrix((np.array([3, 4]), (np.array([0, 1]), np.array([1, 0]))),
+                       csc_matrix((numpy.array([3, 4]),
+                                  (numpy.array([0, 1]), numpy.array([1, 0]))),
                                   shape=(3, 3)))
         self.model2._meta = {"dependencies": [{"model": "docfreq", "uuid": "uuid"}]}
         self.merge_results = [[0, 1, 0], [2, 0, 0], [0, 0, 0], [0, 3, 0], [4, 0, 0], [0, 0, 0]]

--- a/sourced/ml/tests/test_merge_coocc_entry.py
+++ b/sourced/ml/tests/test_merge_coocc_entry.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 import unittest
 
-import numpy as np
+import numpy
 
 from sourced.ml.cmd.merge_coocc import merge_coocc, load_and_check, MAX_INT32
 from sourced.ml.models import Cooccurrences
@@ -32,9 +32,9 @@ class MergeCooccEntry(unittest.TestCase):
         res = Cooccurrences().load(output)
         self.assertEqual(len(res.tokens), len(coocc.tokens))
         permutation = [coocc.tokens.index(token) for token in res.tokens]
-        self.assertTrue(np.all(res.matrix.todense() ==
-                               copies_number *
-                               coocc.matrix.todense()[permutation][:, permutation]))
+        self.assertTrue(numpy.all(res.matrix.todense() ==
+                                  copies_number *
+                                  coocc.matrix.todense()[permutation][:, permutation]))
 
     def copy_models(self, model_path, to_dir, n):
         coocc_filename = os.path.split(model_path)[1]
@@ -67,11 +67,11 @@ class MergeCooccEntry(unittest.TestCase):
             self.assertEqual(len(list(load_and_check(args.input, logging.getLogger("test")))), 2)
 
             c_neg = Cooccurrences().load(args.input[0])
-            c_neg.matrix.data = np.uint32(c_neg.matrix.data)
+            c_neg.matrix.data = numpy.uint32(c_neg.matrix.data)
             c_neg.matrix.data[0] = MAX_INT32 + 1
             c_neg.save(args.input[0])
             for path, coocc in load_and_check(args.input, logging.getLogger("test")):
-                self.assertTrue(np.all(coocc.matrix.data <= MAX_INT32))
+                self.assertTrue(numpy.all(coocc.matrix.data <= MAX_INT32))
                 break
 
     @unittest.skipUnless(sys.version_info < (3, 7), "Python 3.7 is not yet supported")
@@ -85,8 +85,8 @@ class MergeCooccEntry(unittest.TestCase):
             merge_coocc(args)
 
             result = Cooccurrences().load(args.output)
-            self.assertTrue(np.all(result.matrix.data <= MAX_INT32))
-            self.assertTrue(np.all(result.matrix.data >= 0))
+            self.assertTrue(numpy.all(result.matrix.data <= MAX_INT32))
+            self.assertTrue(numpy.all(result.matrix.data >= 0))
 
     def test_overflow_without_spark(self):
         with tempfile.TemporaryDirectory(prefix="merge-coocc-entry-test") as input_dir:
@@ -98,8 +98,8 @@ class MergeCooccEntry(unittest.TestCase):
             merge_coocc(args)
 
             result = Cooccurrences().load(args.output)
-            self.assertTrue(np.all(result.matrix.data <= MAX_INT32))
-            self.assertTrue(np.all(result.matrix.data >= 0))
+            self.assertTrue(numpy.all(result.matrix.data <= MAX_INT32))
+            self.assertTrue(numpy.all(result.matrix.data >= 0))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Waren Long <waren@sourced.tech>

This is only a temporary fix for https://github.com/src-d/ml/issues/332 as I'd like to remove pandas df to use python RDD in `id2role-eval`. However I'd need to write the tests for this command, so it's not a quick fix