### PR TITLE
Use COPY instead of ADD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM srcd/ml-core
 
-ADD setup.py package
-ADD sourced package/sourced
+COPY setup.py package
+COPY sourced package/sourced
 RUN pip3 install --no-cache-dir ./package && rm -rf package
 
 EXPOSE 8000


### PR DESCRIPTION
Hello,

The use of COPY is preferred over ADD when additional functionalities of ADD are not being used (like spraying the contents of a tar in a folder).

Ref:https://docs.docker.com/engine/articles/dockerfile_best-practices/#add-or-copy

Thanks.