### PR TITLE
Remove pyspark import from the coocc model

### DIFF
--- a/sourced/ml/__init__.py
+++ b/sourced/ml/__init__.py
@@ -6,4 +6,4 @@ try:
 except ImportError:
     pass
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/sourced/ml/models/coocc.py
+++ b/sourced/ml/models/coocc.py
@@ -1,7 +1,6 @@
 from modelforge.model import (
     assemble_sparse_matrix, disassemble_sparse_matrix, merge_strings, Model, split_strings)
 from modelforge.models import register_model
-import pyspark
 
 from sourced.ml.models.license import DEFAULT_LICENSE
 
@@ -55,7 +54,7 @@ Matrix: shape: %s non-zero: %d""" % (
         return {"tokens": merge_strings(self.tokens),
                 "matrix": disassemble_sparse_matrix(self.matrix)}
 
-    def matrix_to_rdd(self, spark_context: pyspark.SparkContext) -> pyspark.RDD:
+    def matrix_to_rdd(self, spark_context: "pyspark.SparkContext") -> "pyspark.RDD":
         self._log.info("Convert coocc model to RDD...")
         rdd_row = spark_context.parallelize(self._matrix.row)
         rdd_col = spark_context.parallelize(self._matrix.col)


### PR DESCRIPTION
To make tests in https://github.com/src-d/style-analyzer/pull/619 pass inside docker where we do not have pyspark